### PR TITLE
fix: increase default max_new_tokens for thinking models

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ async def main():
         tokenizer=tokenizer,
         base_url="http://localhost:8000",
         model_id="Qwen/Qwen3-4B-Thinking-2507",
+        params={
+            "max_new_tokens": 10240,
+        },
     )
 
     # Create agent with tools


### PR DESCRIPTION
Default max_new_tokens of sglang is just 128 which is too small given the example uses a thinking model.

Fixes #2 