### PR TITLE
feat(token): add routing replay support for MoE models

### DIFF
--- a/src/strands_sglang/sglang.py
+++ b/src/strands_sglang/sglang.py
@@ -83,6 +83,7 @@ class SGLangModel(Model):
         sampling_params: dict[str, Any] | None  # Passed to /generate endpoint
         return_logprob: bool | None  # Return logprobs for all tokens (default: True)
         enable_thinking: bool | None  # Enable thinking mode for Qwen3 hybrid models
+        return_routed_experts: bool | None  # Record MoE routing decisions for routing replay
 
     def __init__(
         self,
@@ -340,6 +341,7 @@ class SGLangModel(Model):
         config = self.get_config()
         sampling_params: dict[str, Any] = dict(config.get("sampling_params") or {})
         return_logprob = config.get("return_logprob", True)
+        return_routed_experts = config.get("return_routed_experts", False)
         new_input_tokens = self.tokenize_prompt_messages(messages, system_prompt)
         # Tracking token IDs in token_manager to ensure the token-in feature
         input_ids = self.token_manager.token_ids + (new_input_tokens or [])
@@ -355,6 +357,8 @@ class SGLangModel(Model):
                 sampling_params=sampling_params,
                 return_logprob=return_logprob,
                 logprob_start_len=0 if return_logprob else None,
+                return_routed_experts=return_routed_experts,
+                routed_experts_start_len=len(self.token_manager) if return_routed_experts else None,
             )
 
             # Extract response data
@@ -390,6 +394,11 @@ class SGLangModel(Model):
         if output_ids:
             self.token_manager.add_response(token_ids=output_ids, logprobs=output_logprobs)
         self._processed_message_count = len(messages) + 1
+
+        # Accumulate routed experts for routing replay
+        routed_experts_data = meta_info.get("routed_experts") if return_routed_experts else None
+        if routed_experts_data:
+            self.token_manager.add_routed_experts(routed_experts_data)
 
         # End text block, start tool use blocks if there are any tool calls
         yield {"contentBlockStop": {}}

--- a/src/strands_sglang/token.py
+++ b/src/strands_sglang/token.py
@@ -22,10 +22,12 @@ For RL training, you typically want:
 - token_ids: Flat list of all tokens for the trajectory
 - loss_mask: Integer mask for loss computation (1 = model output, 0 = prompt/tool)
 - logprobs: Log probabilities for policy gradient
+- routed_experts: Base64-encoded MoE routing decisions for routing replay
 """
 
 from __future__ import annotations
 
+import base64
 from dataclasses import dataclass
 
 
@@ -74,10 +76,12 @@ class TokenManager:
     def __init__(self) -> None:
         """Create a TokenManager."""
         self._segments: list[list[Token]] = []
+        self._routed_expert_chunks: list[bytes] = []
 
     def reset(self) -> None:
         """Reset token accumulation for a new episode."""
         self._segments = []
+        self._routed_expert_chunks = []
 
     def add_prompt(self, token_ids: list[int], logprobs: list[float] | None = None) -> None:
         """Add a prompt segment (system messages, user input, tool results).
@@ -123,6 +127,36 @@ class TokenManager:
             for i, tid in enumerate(token_ids)
         ]
         self._segments.append(tokens)
+
+    def add_routed_experts(self, data: str) -> None:
+        """Add a base64-encoded routed experts chunk from an SGLang response.
+
+        SGLang returns routed experts as a base64-encoded string of flattened
+        int32 values with shape ``[num_tokens, num_layers, top_k]``. Each call
+        to this method appends the decoded bytes so that the full trajectory
+        can be reconstructed via the :pyattr:`routed_experts` property.
+
+        Args:
+            data: Base64-encoded routed experts string from ``meta_info["routed_experts"]``.
+        """
+        self._routed_expert_chunks.append(base64.b64decode(data))
+
+    @property
+    def routed_experts(self) -> str | None:
+        """Get accumulated routed experts as a base64-encoded string.
+
+        Returns the concatenation of all chunks collected via
+        :pymeth:`add_routed_experts`, re-encoded as a single base64 string
+        matching the format returned by SGLang's ``/generate`` endpoint.
+
+        Returns:
+            Base64-encoded string of int32 expert IDs with logical shape
+            ``[total_tokens, num_layers, top_k]``, or ``None`` if no routing
+            data has been recorded.
+        """
+        if not self._routed_expert_chunks:
+            return None
+        return base64.b64encode(b"".join(self._routed_expert_chunks)).decode("ascii")
 
     @property
     def tokens(self) -> list[Token]:

--- a/tests/unit/test_sglang.py
+++ b/tests/unit/test_sglang.py
@@ -14,7 +14,9 @@
 
 """Unit tests for SGLangModel helper methods (no API calls needed)."""
 
-from unittest.mock import MagicMock
+import base64
+import struct
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -172,11 +174,7 @@ class TestExtractLogprobs:
 
     def test_extract_from_meta_info(self, model):
         """Extract logprobs from meta_info."""
-        event = {
-            "meta_info": {
-                "output_token_logprobs": [[-0.5, 100], [-0.3, 200], [-0.1, 300]]
-            }
-        }
+        event = {"meta_info": {"output_token_logprobs": [[-0.5, 100], [-0.3, 200], [-0.1, 300]]}}
         result = model._extract_logprobs(event, "output_token_logprobs")
 
         assert result == [-0.5, -0.3, -0.1]
@@ -215,9 +213,7 @@ class TestYieldToolUseEvents:
 
     def test_single_tool_call(self, model):
         """Yield events for single tool call."""
-        tool_calls = [
-            ToolParseResult(id="call_123", name="calculator", input={"expr": "2+2"})
-        ]
+        tool_calls = [ToolParseResult(id="call_123", name="calculator", input={"expr": "2+2"})]
         events = list(model._yield_tool_use_events(tool_calls))
 
         assert len(events) == 3
@@ -251,9 +247,7 @@ class TestYieldToolUseEvents:
 
     def test_error_tool_call(self, model):
         """Error tool call includes raw content."""
-        tool_calls = [
-            ToolParseResult(id="call_err", name="broken", input={}, raw="invalid json")
-        ]
+        tool_calls = [ToolParseResult(id="call_err", name="broken", input={}, raw="invalid json")]
         events = list(model._yield_tool_use_events(tool_calls))
 
         assert len(events) == 3
@@ -434,3 +428,306 @@ class TestSortToolResults:
         sorted_msgs = model._sort_tool_results(messages)
 
         assert sorted_msgs == messages
+
+
+# ---------------------------------------------------------------------------
+# Helpers for routing replay end-to-end tests
+# ---------------------------------------------------------------------------
+
+NUM_LAYERS = 2
+TOP_K = 2
+EXPERTS_PER_TOKEN = NUM_LAYERS * TOP_K  # int32 values per token
+
+
+def _make_routing_b64(expert_ids: list[int]) -> str:
+    """Encode int32 expert IDs to base64 (matching SGLang format)."""
+    return base64.b64encode(struct.pack(f"<{len(expert_ids)}i", *expert_ids)).decode("ascii")
+
+
+def _decode_routing_b64(data: str) -> list[int]:
+    """Decode base64 routing data back to int32 expert IDs."""
+    raw = base64.b64decode(data)
+    return list(struct.unpack(f"<{len(raw) // 4}i", raw))
+
+
+def _make_generate_response(
+    text: str,
+    output_ids: list[int],
+    num_input_tokens: int,
+    *,
+    routing_start: int = 0,
+    include_routing: bool = False,
+) -> dict:
+    """Build a mock SGLang /generate response.
+
+    When include_routing is True, generates deterministic per-token routing:
+    token at position i gets experts [i*10, i*10+1, i*10+2, i*10+3]
+    (for NUM_LAYERS=2, TOP_K=2).
+    """
+    num_output = len(output_ids)
+    total = num_input_tokens + num_output
+
+    meta_info = {
+        "finish_reason": {"type": "stop"},
+        "prompt_tokens": num_input_tokens,
+        "completion_tokens": num_output,
+        "e2e_latency": 0.1,
+    }
+
+    if include_routing:
+        # Generate routing for tokens from routing_start to total-1
+        expert_ids = []
+        for pos in range(routing_start, total):
+            expert_ids.extend([pos * 10 + k for k in range(EXPERTS_PER_TOKEN)])
+        meta_info["routed_experts"] = _make_routing_b64(expert_ids)
+
+    input_logprobs = [[-0.1, tid] for tid in range(num_input_tokens)]
+    output_logprobs = [[-0.2, tid] for tid in output_ids]
+
+    return {
+        "text": text,
+        "output_ids": output_ids,
+        "meta_info": meta_info,
+        "input_token_logprobs": input_logprobs,
+        "output_token_logprobs": output_logprobs,
+    }
+
+
+async def _collect_stream(stream):
+    """Collect all events from an async iterable."""
+    return [event async for event in stream]
+
+
+class TestRoutedExpertsE2E:
+    """End-to-end tests for routing replay through SGLangModel.stream()."""
+
+    @pytest.fixture
+    def mock_tokenizer(self):
+        tokenizer = MagicMock()
+        tokenizer.apply_chat_template.return_value = "formatted prompt"
+        # Each encode call returns a fresh list; tests override via side_effect when needed
+        tokenizer.encode.return_value = [10, 20, 30]
+        return tokenizer
+
+    @pytest.fixture
+    def model(self, mock_tokenizer):
+        client = SGLangClient(base_url="http://localhost:30000")
+        return SGLangModel(client=client, tokenizer=mock_tokenizer, return_routed_experts=True)
+
+    async def test_single_turn_routing(self, model):
+        """Single turn: routing covers prompt + response tokens."""
+        prompt_tokens = [10, 20, 30]  # 3 tokens from encode
+        output_ids = [40, 50]  # 2 output tokens
+
+        response = _make_generate_response(
+            text="Hello!",
+            output_ids=output_ids,
+            num_input_tokens=len(prompt_tokens),
+            routing_start=0,
+            include_routing=True,
+        )
+
+        with patch.object(model.client, "generate", new_callable=AsyncMock, return_value=response):
+            messages = [{"role": "user", "content": [{"text": "Hi"}]}]
+            await _collect_stream(model.stream(messages))
+
+        # Token trajectory
+        assert model.token_manager.token_ids == prompt_tokens + output_ids
+        assert len(model.token_manager) == 5
+
+        # Routing data covers all 5 tokens
+        routing = model.token_manager.routed_experts
+        assert routing is not None
+        decoded = _decode_routing_b64(routing)
+        assert len(decoded) == 5 * EXPERTS_PER_TOKEN
+
+        # Verify deterministic expert IDs: token at position i → [i*10 .. i*10+3]
+        for pos in range(5):
+            chunk = decoded[pos * EXPERTS_PER_TOKEN : (pos + 1) * EXPERTS_PER_TOKEN]
+            assert chunk == [pos * 10 + k for k in range(EXPERTS_PER_TOKEN)]
+
+    async def test_multi_turn_with_tool_call(self, model, mock_tokenizer):
+        """Multi-turn: prompt → tool call → tool result → final answer.
+
+        Verifies routing accumulates across turns and aligns with token_ids.
+        """
+        # --- Turn 1: user prompt → model generates tool call ---
+        prompt_tokens_t1 = [10, 20, 30]
+        output_ids_t1 = [40, 50]
+        mock_tokenizer.encode.return_value = prompt_tokens_t1
+
+        response_t1 = _make_generate_response(
+            text='<tool_call>{"name": "calc", "arguments": {"expr": "1+1"}}</tool_call>',
+            output_ids=output_ids_t1,
+            num_input_tokens=len(prompt_tokens_t1),
+            routing_start=0,
+            include_routing=True,
+        )
+
+        with patch.object(model.client, "generate", new_callable=AsyncMock, return_value=response_t1):
+            messages_t1 = [{"role": "user", "content": [{"text": "What is 1+1?"}]}]
+            await _collect_stream(model.stream(messages_t1, tool_specs=[{"name": "calc", "description": "calc"}]))
+
+        assert model.token_manager.token_ids == prompt_tokens_t1 + output_ids_t1
+        total_after_t1 = len(model.token_manager)  # 5
+
+        # --- Turn 2: tool result → model generates final answer ---
+        tool_result_tokens = [60, 70]
+        output_ids_t2 = [80, 90, 100]
+        mock_tokenizer.encode.return_value = tool_result_tokens
+
+        response_t2 = _make_generate_response(
+            text="The answer is 2.",
+            output_ids=output_ids_t2,
+            num_input_tokens=total_after_t1 + len(tool_result_tokens),
+            routing_start=total_after_t1,  # only new tokens
+            include_routing=True,
+        )
+
+        with patch.object(model.client, "generate", new_callable=AsyncMock, return_value=response_t2) as mock_gen:
+            messages_t2 = messages_t1 + [
+                {
+                    "role": "assistant",
+                    "content": [
+                        {"text": '<tool_call>{"name": "calc", "arguments": {"expr": "1+1"}}</tool_call>'},
+                        {"toolUse": {"toolUseId": "call_0000", "name": "calc", "input": {"expr": "1+1"}}},
+                    ],
+                },
+                {
+                    "role": "user",
+                    "content": [
+                        {"toolResult": {"toolUseId": "call_0000", "content": [{"text": "2"}]}},
+                    ],
+                },
+            ]
+            await _collect_stream(model.stream(messages_t2, tool_specs=[{"name": "calc", "description": "calc"}]))
+
+            # Verify routed_experts_start_len was passed correctly
+            call_kwargs = mock_gen.call_args.kwargs
+            assert call_kwargs["return_routed_experts"] is True
+            assert call_kwargs["routed_experts_start_len"] == total_after_t1
+
+        # Full token trajectory
+        expected_ids = prompt_tokens_t1 + output_ids_t1 + tool_result_tokens + output_ids_t2
+        assert model.token_manager.token_ids == expected_ids
+        total_tokens = len(expected_ids)  # 10
+
+        # Routing covers ALL tokens across both turns
+        routing = model.token_manager.routed_experts
+        assert routing is not None
+        decoded = _decode_routing_b64(routing)
+        assert len(decoded) == total_tokens * EXPERTS_PER_TOKEN
+
+        # Verify per-token expert IDs are correct and contiguous
+        for pos in range(total_tokens):
+            chunk = decoded[pos * EXPERTS_PER_TOKEN : (pos + 1) * EXPERTS_PER_TOKEN]
+            assert chunk == [pos * 10 + k for k in range(EXPERTS_PER_TOKEN)]
+
+    async def test_routing_aligns_with_loss_mask(self, model, mock_tokenizer):
+        """Routing entries align 1:1 with token_ids and loss_mask."""
+        prompt_tokens = [10, 20, 30]
+        output_ids = [40, 50]
+        mock_tokenizer.encode.return_value = prompt_tokens
+
+        response = _make_generate_response(
+            text="answer",
+            output_ids=output_ids,
+            num_input_tokens=len(prompt_tokens),
+            routing_start=0,
+            include_routing=True,
+        )
+
+        with patch.object(model.client, "generate", new_callable=AsyncMock, return_value=response):
+            messages = [{"role": "user", "content": [{"text": "Hi"}]}]
+            await _collect_stream(model.stream(messages))
+
+        n_tokens = len(model.token_manager.token_ids)
+        routing_entries = len(_decode_routing_b64(model.token_manager.routed_experts)) // EXPERTS_PER_TOKEN
+
+        assert routing_entries == n_tokens
+        assert len(model.token_manager.loss_mask) == n_tokens
+        assert len(model.token_manager.logprobs) == n_tokens
+
+    async def test_routing_disabled_by_default(self, mock_tokenizer):
+        """When return_routed_experts is not set, no routing data is recorded."""
+        client = SGLangClient(base_url="http://localhost:30000")
+        model = SGLangModel(client=client, tokenizer=mock_tokenizer)  # no return_routed_experts
+
+        mock_tokenizer.encode.return_value = [10, 20]
+        response = _make_generate_response(
+            text="hi",
+            output_ids=[30],
+            num_input_tokens=2,
+            include_routing=False,
+        )
+
+        with patch.object(model.client, "generate", new_callable=AsyncMock, return_value=response) as mock_gen:
+            messages = [{"role": "user", "content": [{"text": "Hi"}]}]
+            await _collect_stream(model.stream(messages))
+
+            # return_routed_experts should be False, routed_experts_start_len should be None
+            call_kwargs = mock_gen.call_args.kwargs
+            assert call_kwargs["return_routed_experts"] is False
+            assert call_kwargs["routed_experts_start_len"] is None
+
+        assert model.token_manager.routed_experts is None
+
+    async def test_routing_absent_from_response(self, model, mock_tokenizer):
+        """If server doesn't return routing data, routed_experts stays None."""
+        mock_tokenizer.encode.return_value = [10, 20]
+        response = _make_generate_response(
+            text="hi",
+            output_ids=[30],
+            num_input_tokens=2,
+            include_routing=False,  # no routed_experts in meta_info
+        )
+
+        with patch.object(model.client, "generate", new_callable=AsyncMock, return_value=response):
+            messages = [{"role": "user", "content": [{"text": "Hi"}]}]
+            await _collect_stream(model.stream(messages))
+
+        assert model.token_manager.routed_experts is None
+
+    async def test_reset_clears_routing(self, model, mock_tokenizer):
+        """model.reset() clears accumulated routing data."""
+        mock_tokenizer.encode.return_value = [10, 20]
+        response = _make_generate_response(
+            text="hi",
+            output_ids=[30],
+            num_input_tokens=2,
+            routing_start=0,
+            include_routing=True,
+        )
+
+        with patch.object(model.client, "generate", new_callable=AsyncMock, return_value=response):
+            messages = [{"role": "user", "content": [{"text": "Hi"}]}]
+            await _collect_stream(model.stream(messages))
+
+        assert model.token_manager.routed_experts is not None
+
+        model.reset()
+
+        assert model.token_manager.routed_experts is None
+
+    async def test_generate_called_with_correct_start_len(self, model, mock_tokenizer):
+        """routed_experts_start_len equals accumulated token count before each call."""
+        # Turn 1
+        mock_tokenizer.encode.return_value = [10, 20, 30]
+        resp1 = _make_generate_response("hi", [40], 3, routing_start=0, include_routing=True)
+
+        with patch.object(model.client, "generate", new_callable=AsyncMock, return_value=resp1) as mock_gen:
+            await _collect_stream(model.stream([{"role": "user", "content": [{"text": "a"}]}]))
+            assert mock_gen.call_args.kwargs["routed_experts_start_len"] == 0  # first call
+
+        # Turn 2: token_manager has 4 tokens
+        mock_tokenizer.encode.return_value = [50, 60]
+        resp2 = _make_generate_response("bye", [70], 6, routing_start=4, include_routing=True)
+
+        with patch.object(model.client, "generate", new_callable=AsyncMock, return_value=resp2) as mock_gen:
+            messages = [
+                {"role": "user", "content": [{"text": "a"}]},
+                {"role": "assistant", "content": [{"text": "hi"}]},
+                {"role": "user", "content": [{"text": "b"}]},
+            ]
+            await _collect_stream(model.stream(messages))
+            assert mock_gen.call_args.kwargs["routed_experts_start_len"] == 4  # 3 prompt + 1 output

--- a/tests/unit/test_token.py
+++ b/tests/unit/test_token.py
@@ -14,6 +14,9 @@
 
 """Unit tests for token module."""
 
+import base64
+import struct
+
 import pytest
 
 from strands_sglang import Token, TokenManager
@@ -255,6 +258,16 @@ class TestTokenManagerReset:
         assert manager.tokens == []
         assert manager.segments == []
 
+    def test_reset_clears_routed_experts(self):
+        """reset clears accumulated routed experts."""
+        manager = TokenManager()
+        chunk = base64.b64encode(b"\x01\x00\x00\x00").decode("ascii")
+        manager.add_routed_experts(chunk)
+
+        manager.reset()
+
+        assert manager.routed_experts is None
+
     def test_reset_allows_reuse(self):
         """Manager can be reused after reset."""
         manager = TokenManager()
@@ -332,3 +345,63 @@ class TestEdgeCases:
         manager = TokenManager()
         manager.add_prompt([100000, 999999])
         assert manager.token_ids == [100000, 999999]
+
+
+def _make_routed_experts_b64(expert_ids: list[int]) -> str:
+    """Helper: encode a list of int32 expert IDs to base64 (matching SGLang format)."""
+    raw = struct.pack(f"<{len(expert_ids)}i", *expert_ids)
+    return base64.b64encode(raw).decode("ascii")
+
+
+class TestRoutedExperts:
+    """Tests for routed experts accumulation."""
+
+    def test_empty_manager_returns_none(self):
+        """No routing data returns None."""
+        manager = TokenManager()
+        assert manager.routed_experts is None
+
+    def test_single_chunk(self):
+        """Single chunk round-trips through base64 correctly."""
+        manager = TokenManager()
+        experts = [0, 1, 2, 3]
+        chunk = _make_routed_experts_b64(experts)
+
+        manager.add_routed_experts(chunk)
+
+        result = manager.routed_experts
+        assert result is not None
+        decoded = struct.unpack(f"<{len(experts)}i", base64.b64decode(result))
+        assert list(decoded) == experts
+
+    def test_multi_turn_accumulation(self):
+        """Multiple chunks are concatenated in order."""
+        manager = TokenManager()
+
+        # Turn 1: prompt + response routing (3 tokens, 1 layer, top_k=2)
+        turn1_experts = [10, 20, 30, 40, 50, 60]  # 3 tokens * 1 layer * 2 experts
+        manager.add_routed_experts(_make_routed_experts_b64(turn1_experts))
+
+        # Turn 2: new tokens routing (2 tokens, 1 layer, top_k=2)
+        turn2_experts = [70, 80, 90, 100]  # 2 tokens * 1 layer * 2 experts
+        manager.add_routed_experts(_make_routed_experts_b64(turn2_experts))
+
+        result = manager.routed_experts
+        assert result is not None
+        all_experts = turn1_experts + turn2_experts
+        decoded = struct.unpack(f"<{len(all_experts)}i", base64.b64decode(result))
+        assert list(decoded) == all_experts
+
+    def test_reset_then_reuse(self):
+        """Routing data can be accumulated after reset."""
+        manager = TokenManager()
+        manager.add_routed_experts(_make_routed_experts_b64([1, 2]))
+        manager.reset()
+
+        new_experts = [5, 6, 7]
+        manager.add_routed_experts(_make_routed_experts_b64(new_experts))
+
+        result = manager.routed_experts
+        assert result is not None
+        decoded = struct.unpack(f"<{len(new_experts)}i", base64.b64decode(result))
+        assert list(decoded) == new_experts


### PR DESCRIPTION
## Summary
- Add `return_routed_experts` config option to record MoE routing decisions
- Accumulate routed experts turn-by-turn in `TokenManager`, returned as base64 matching SGLang format
- Use incremental `routed_experts_start_len` to avoid redundant data across turns