### PR TITLE
fix: always count tool iterations/calls regardless of limits  

### DIFF
--- a/src/strands_sglang/tool_limiter.py
+++ b/src/strands_sglang/tool_limiter.py
@@ -97,8 +97,6 @@ class ToolLimiter(HookProvider):
         - Counts on assistant messages with toolUse (model requesting tools)
         - Raises on user messages with toolResult (iteration complete)
         """
-        if self.max_tool_iters is None and self.max_tool_calls is None:
-            return
 
         message = event.message
         content = message.get("content", [])


### PR DESCRIPTION
## Summary

  `ToolLimiter` skips counting `tool_iter_count` and `tool_call_count` when both
  `max_tool_iters` and `max_tool_calls` are `None`, causing downstream consumers (e.g.
   [strands-env](https://github.com/horizon-rl/strands-env)) to report `tool_iters=0` and `tool_calls=0` in metrics even when the agent makes dozens of tool calls.

  ## Root Cause

  The early return in `_on_message_added`:

  ```python
  if self.max_tool_iters is None and self.max_tool_calls is None:
      return
```
  
  The limit-enforcement checks below already guard with `if self.max_tool_iters is not
  None` / `if self.max_tool_calls is not None`, so the early return is redundant for limiting and harmful for counting.


  ### Impact

  - Counting: tool_iter_count and tool_call_count are now always accurate
  - Limiting: No change — is not None guards already prevent false enforcement