### PR TITLE
chore: use strands-agents[openai] extra, drop standalone openai dep

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "strands-sglang"
-version = "0.2.4"
+version = "0.2.5.dev0"
 description = "SGLang model provider for Strands Agents SDK with Token-in/Token-out support for agentic RL training."
 readme = "README.md"
 requires-python = ">=3.10"
@@ -26,11 +26,10 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-    "strands-agents",
+    "strands-agents[openai]",
     "aiohttp>=3.8.0",
     "transformers>=4.0.0,<5.0.0",
     "jinja2",
-    "openai",
 ]
 
 [project.urls]


### PR DESCRIPTION
## Summary
- Replace standalone `openai` dependency with `strands-agents[openai]` extra — we only use `openai` transitively through `strands.models.openai.OpenAIModel`, so let strands-agents manage the version pin
- Bump version to `v0.2.5.dev0`

## Test plan
- [x] Unit tests pass (254/254) in isolated venv
- [x] Integration tests pass (65/65) against live SGLang server
- [x] Linting passes (ruff check + format)

🤖 Generated with [Claude Code](https://claude.com/claude-code)