### PR TITLE
feat(tool_parsers): add Kimi K2 and DeepSeek V3.2 tool parsers

### DIFF
--- a/src/strands_sglang/sglang.py
+++ b/src/strands_sglang/sglang.py
@@ -212,13 +212,27 @@ class SGLangModel(Model):
     ) -> str:
         """Format messages into a prompt ready for model generation.
 
-        Applies the HuggingFace chat template with `add_generation_prompt=True`,
-        which appends the assistant turn prefix for the model to continue.
+        Tries the tool parser's ``format_prompt`` first (for models without a
+        Jinja chat template, e.g. DeepSeek-V3.2).  Falls back to the
+        HuggingFace ``tokenizer.apply_chat_template()`` when the parser
+        returns ``None``.
 
         The result is manually tokenized (not model-generated) and added to
         the token trajectory with `loss_mask=False`.
         """
         chat_messages = self.format_request_messages(messages, system_prompt)
+
+        # Try parser-provided encoding first (for models without Jinja templates)
+        if self.tool_parser is not None:
+            result = self.tool_parser.format_prompt(
+                chat_messages,
+                tools=tools,
+                add_generation_prompt=True,
+                enable_thinking=self.config.get("enable_thinking"),
+            )
+            if result is not None:
+                return result
+
         return self.tokenizer.apply_chat_template(
             conversation=chat_messages,
             tools=tools,
@@ -389,7 +403,14 @@ class SGLangModel(Model):
         yield {"contentBlockStop": {}}
 
         # Parse tool calls and yield events
-        parsed_tool_calls = self.tool_parser.parse(text)
+        # Decode output_ids locally when the parser needs special tokens preserved
+        # (e.g. DeepSeek-V3.2's ｜DSML｜ prefix is stripped by SGLang's default detokenizer)
+        parse_text = (
+            self.tokenizer.decode(output_ids, skip_special_tokens=self.tool_parser.skip_special_tokens)
+            if output_ids
+            else text
+        )
+        parsed_tool_calls = self.tool_parser.parse(parse_text)
         for event in self._yield_tool_use_events(parsed_tool_calls):
             yield event
 

--- a/src/strands_sglang/tool_parsers/__init__.py
+++ b/src/strands_sglang/tool_parsers/__init__.py
@@ -31,8 +31,10 @@ Adding a new parser:
 from .base import TOOL_PARSER_REGISTRY, ToolParser, ToolParseResult, get_tool_parser
 
 # Import parsers to trigger registration via @register_tool_parser decorator
+from .deepseek_v32 import DeepSeekV32ToolParser
 from .glm import GLMToolParser
 from .hermes import HermesToolParser
+from .kimi_k2 import KimiK2ToolParser
 from .qwen_xml import QwenXMLToolParser
 
 __all__ = [
@@ -40,8 +42,10 @@ __all__ = [
     "ToolParseResult",
     "ToolParser",
     # Parsers
+    "DeepSeekV32ToolParser",
     "GLMToolParser",
     "HermesToolParser",
+    "KimiK2ToolParser",
     "QwenXMLToolParser",
     # Registry
     "TOOL_PARSER_REGISTRY",

--- a/src/strands_sglang/tool_parsers/base.py
+++ b/src/strands_sglang/tool_parsers/base.py
@@ -90,6 +90,12 @@ class ToolParser(ABC):
     DEFAULT_THINK_START_TOKEN = "<think>"
     DEFAULT_THINK_END_TOKEN = "</think>"
 
+    #: Whether to skip special tokens when decoding output_ids for tool parsing.
+    #: SGLang's server returns text with skip_special_tokens=True by default,
+    #: which strips tokens like ｜DSML｜ that are needed for parsing.
+    #: Override to False in subclasses whose tool call format uses special tokens.
+    skip_special_tokens: bool = True
+
     def __init__(
         self,
         tool_start_token: str = DEFAULT_TOOL_START_TOKEN,
@@ -132,6 +138,34 @@ class ToolParser(ABC):
         Default is no separator.
         """
         return ""
+
+    def format_prompt(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict] | None = None,
+        *,
+        add_generation_prompt: bool = True,
+        enable_thinking: bool | None = None,
+    ) -> str | None:
+        """Format messages into a prompt string.
+
+        Override in subclasses for models that don't ship a Jinja chat template
+        (e.g., DeepSeek-V3.2 which uses ``encoding/encoding_dsv32.py``).
+
+        When this returns a string, ``SGLangModel`` uses it instead of
+        ``tokenizer.apply_chat_template()``.  The default returns ``None``,
+        which means "use the tokenizer's Jinja template as usual".
+
+        Args:
+            messages: Conversation messages in OpenAI format.
+            tools: Tool definitions in OpenAI format, or None.
+            add_generation_prompt: Whether to append the generation prompt.
+            enable_thinking: Whether thinking/reasoning mode is active.
+
+        Returns:
+            Formatted prompt string, or None to fall back to apply_chat_template.
+        """
+        return None
 
     @abstractmethod
     def parse(self, text: str) -> list[ToolParseResult]:

--- a/src/strands_sglang/tool_parsers/deepseek_v32.py
+++ b/src/strands_sglang/tool_parsers/deepseek_v32.py
@@ -1,0 +1,311 @@
+# Copyright 2025 Horizon RL Contributors
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tool call parser and prompt encoder for DeepSeek-V3.2 models.
+
+DeepSeek-V3.2 uses DSML-prefixed XML-like tags with typed parameters.
+All tags use the ``｜DSML｜`` prefix (fullwidth pipes U+FF5C)::
+
+    <｜DSML｜function_calls>
+    <｜DSML｜invoke name="func_name">
+    <｜DSML｜parameter name="arg1" string="true">string_value</｜DSML｜parameter>
+    <｜DSML｜parameter name="arg2" string="false">123</｜DSML｜parameter>
+    </｜DSML｜invoke>
+    </｜DSML｜function_calls>
+
+The ``string`` attribute controls value interpretation: ``"true"`` keeps the
+raw string, ``"false"`` parses it as JSON (number, bool, list, object).
+
+DeepSeek-V3.2 does not ship a Jinja chat template. When ``model_name_or_path``
+is provided, :meth:`~DeepSeekV32ToolParser.format_prompt` loads the model's
+``encoding/encoding_dsv32.py`` and delegates to it directly.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import logging
+import re
+import types
+from typing import Any
+
+from typing_extensions import override
+
+from .base import ToolParser, ToolParseResult, register_tool_parser
+
+logger = logging.getLogger(__name__)
+
+# DeepSeek-V3.2 special token characters
+_FP = "\uff5c"  # ｜ fullwidth pipe
+_HS = "\u2581"  # ▁ half-width space
+
+# DSML prefix used in all tool call tags
+_DSML = f"{_FP}DSML{_FP}"  # ｜DSML｜
+
+# EOS token used as message separator between assistant output and tool results
+_EOS_TOKEN = f"<{_FP}end{_HS}of{_HS}sentence{_FP}>"
+
+# Tool call section delimiters
+_FC_START = f"<{_DSML}function_calls>"
+_FC_END = f"</{_DSML}function_calls>"
+
+
+def _load_encoding_module(model_name_or_path: str) -> types.ModuleType:
+    """Load ``encoding/encoding_dsv32.py`` from a HuggingFace model repo.
+
+    Uses ``huggingface_hub.hf_hub_download`` for remote model IDs and falls
+    back to direct file-system access for local paths.
+
+    Args:
+        model_name_or_path: HuggingFace model ID or local directory path.
+
+    Returns:
+        The imported encoding module.
+
+    Raises:
+        FileNotFoundError: If the encoding file cannot be found.
+        ImportError: If ``huggingface_hub`` is not installed (remote models only).
+    """
+    import os
+
+    encoding_filename = os.path.join("encoding", "encoding_dsv32.py")
+
+    # Local path
+    if os.path.isdir(model_name_or_path):
+        filepath = os.path.join(model_name_or_path, encoding_filename)
+        if not os.path.isfile(filepath):
+            raise FileNotFoundError(f"Encoding file not found: {filepath}")
+    else:
+        # Remote HuggingFace model ID
+        try:
+            from huggingface_hub import hf_hub_download
+        except ImportError as exc:
+            raise ImportError(
+                "huggingface_hub is required to download encoding_dsv32.py "
+                f"from remote model {model_name_or_path!r}. "
+                "Install it with: pip install huggingface_hub"
+            ) from exc
+        filepath = hf_hub_download(model_name_or_path, encoding_filename)
+
+    spec = importlib.util.spec_from_file_location("encoding_dsv32", filepath)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load module from {filepath}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    logger.info("Loaded encoding module from %s", filepath)
+    return module
+
+
+def _parse_param_value(value: str, is_string: bool) -> Any:
+    """Parse a parameter value based on its string attribute.
+
+    Args:
+        value: Raw parameter value text.
+        is_string: If True, return as-is. If False, attempt JSON decode.
+
+    Returns:
+        Parsed value (string, number, bool, list, or dict).
+    """
+    if is_string:
+        return value
+    try:
+        return json.loads(value)
+    except json.JSONDecodeError:
+        return value
+
+
+@register_tool_parser("deepseek_v32")
+class DeepSeekV32ToolParser(ToolParser):
+    """Parser for DeepSeek-V3.2 DSML-prefixed tool call format.
+
+    Format:
+        <｜DSML｜function_calls>
+        <｜DSML｜invoke name="func_name">
+        <｜DSML｜parameter name="arg1" string="true">string_value</｜DSML｜parameter>
+        <｜DSML｜parameter name="arg2" string="false">123</｜DSML｜parameter>
+        </｜DSML｜invoke>
+        </｜DSML｜function_calls>
+
+    Parameters have a ``string`` attribute that controls value parsing:
+    ``"true"`` preserves the raw string, ``"false"`` attempts JSON decode
+    for non-string types (numbers, booleans, lists, objects).
+
+    When no ``<｜DSML｜parameter>`` tags are found, the invoke body is tried
+    as raw JSON as a fallback.
+
+    Think Block Handling:
+        Models with reasoning capabilities may output draft tool calls
+        inside <think>...</think> blocks. These are excluded by default
+        to avoid executing planning/reasoning tool calls.
+
+    Chat Template Notes:
+        DeepSeek-V3.2 does not ship a Jinja chat template. Pass
+        ``model_name_or_path`` to load the model's own
+        ``encoding/encoding_dsv32.py`` for prompt formatting via
+        :meth:`format_prompt`.
+    """
+
+    skip_special_tokens: bool = False
+
+    INVOKE_PATTERN = re.compile(
+        rf"<{re.escape(_DSML)}invoke\s+name=\"([^\"]+)\"\s*>(.*?)</{re.escape(_DSML)}invoke>",
+        re.DOTALL,
+    )
+
+    PARAM_PATTERN = re.compile(
+        rf"<{re.escape(_DSML)}parameter\s+name=\"([^\"]+)\"\s+string=\"(true|false)\"\s*>"
+        rf"(.*?)</{re.escape(_DSML)}parameter>",
+        re.DOTALL,
+    )
+
+    def __init__(self, *, model_name_or_path: str = "deepseek-ai/DeepSeek-V3.2", **kwargs: Any) -> None:
+        """Initialize the DeepSeek-V3.2 tool parser.
+
+        Args:
+            model_name_or_path: HuggingFace model ID or local path.
+                Defaults to ``"deepseek-ai/DeepSeek-V3.2"`` which auto-downloads
+                ``encoding/encoding_dsv32.py`` via ``hf_hub_download``.
+            **kwargs: Forwarded to :class:`ToolParser` (custom token overrides).
+        """
+        kwargs.setdefault("tool_start_token", _FC_START)
+        kwargs.setdefault("tool_end_token", _FC_END)
+        super().__init__(**kwargs)
+        self._encoding_module = _load_encoding_module(model_name_or_path)
+
+    @override
+    @property
+    def message_separator(self) -> str:
+        """DeepSeek-V3.2 EOS token to terminate assistant turn before tool results."""
+        return _EOS_TOKEN
+
+    @override
+    def format_prompt(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict] | None = None,
+        *,
+        add_generation_prompt: bool = True,
+        enable_thinking: bool | None = None,
+    ) -> str | None:
+        """Format messages using the model's ``encoding_dsv32.encode_messages()``.
+
+        For the first call (full conversation), delegates to the encoding module.
+        For incremental calls (tool-result-only messages), uses
+        :meth:`_format_incremental` to avoid ``encode_messages()`` crashing
+        when it looks backward for a preceding assistant message.
+        """
+        thinking_mode = "thinking" if enable_thinking else "chat"
+
+        # Incremental path: only tool results, no system/user context
+        if all(m.get("role") == "tool" for m in messages):
+            return self._format_incremental(messages, thinking_mode, add_generation_prompt)
+
+        # The reference render_message reads tools from msg.get("tools"),
+        # so attach them to the system message for encode_messages to handle.
+        if tools:
+            messages = [dict(m) for m in messages]  # shallow copy to avoid mutation
+            if messages and messages[0].get("role") == "system":
+                messages[0] = {**messages[0], "tools": tools}
+            else:
+                messages.insert(0, {"role": "system", "content": "", "tools": tools})
+
+        return self._encoding_module.encode_messages(messages, thinking_mode=thinking_mode)
+
+    def _format_incremental(
+        self, messages: list[dict[str, Any]], thinking_mode: str, add_generation_prompt: bool
+    ) -> str:
+        """Format tool result messages for incremental tokenization.
+
+        ``encode_messages()`` expects the full conversation and looks backward
+        for the preceding assistant message with tool calls. On subsequent turns
+        only new messages (tool results) are passed, causing an AssertionError.
+
+        This method formats tool results directly and appends the generation
+        prompt so the model knows to start its next reasoning turn.
+        """
+        result = "\n\n<function_results>"
+        for msg in messages:
+            if msg.get("role") == "tool":
+                result += "\n<result>" + msg.get("content", "") + "</result>"
+        result += "\n</function_results>"
+        if add_generation_prompt:
+            gen = "<think>" if thinking_mode == "thinking" else "</think>"
+            result += "\n\n" + gen
+        return result
+
+    # ── Parsing ───────────────────────────────────────────────────────────
+
+    @override
+    def parse(self, text: str) -> list[ToolParseResult]:
+        """Parse tool calls from DeepSeek-V3.2 model output.
+
+        Extracts ``<｜DSML｜invoke>`` blocks from within
+        ``<｜DSML｜function_calls>`` sections, then parses typed
+        ``<｜DSML｜parameter>`` tags into arguments.
+
+        Args:
+            text: Model output text.
+
+        Returns:
+            List of tool call results (successful and errors).
+        """
+        # Remove think blocks to avoid parsing draft tool calls from reasoning
+        text = self.think_pattern.sub("", text)
+
+        tool_calls: list[ToolParseResult] = []
+        call_index = 0
+
+        for fc_match in self.tool_pattern.finditer(text):
+            fc_content = fc_match.group(1)
+
+            for invoke_match in self.INVOKE_PATTERN.finditer(fc_content):
+                func_name = invoke_match.group(1)
+                invoke_body = invoke_match.group(2)
+                tool_call_id = f"call_{call_index:04d}"  # Sequential IDs for sortability
+                call_index += 1
+
+                # Parse typed <｜DSML｜parameter> tags
+                arguments: dict[str, Any] = {}
+                for param_match in self.PARAM_PATTERN.finditer(invoke_body):
+                    param_name = param_match.group(1)
+                    is_string = param_match.group(2) == "true"
+                    raw_value = param_match.group(3)
+                    arguments[param_name] = _parse_param_value(raw_value, is_string)
+
+                if not arguments:
+                    # Fallback: try parsing invoke body as raw JSON
+                    body = invoke_body.strip()
+                    if body:
+                        try:
+                            arguments = json.loads(body)
+                            if not isinstance(arguments, dict):
+                                logger.warning("Tool parse error: arguments is not a dict for %s", func_name)
+                                arguments = {}
+                        except json.JSONDecodeError:
+                            logger.warning("Tool parse error: no params and body not JSON for %s", func_name)
+                            tool_calls.append(
+                                ToolParseResult.from_parse_error(id=tool_call_id, raw=invoke_body, name=func_name)
+                            )
+                            continue
+
+                tool_calls.append(
+                    ToolParseResult(
+                        id=tool_call_id,
+                        name=func_name,
+                        input=arguments,
+                    )
+                )
+
+        return tool_calls

--- a/src/strands_sglang/tool_parsers/kimi_k2.py
+++ b/src/strands_sglang/tool_parsers/kimi_k2.py
@@ -1,0 +1,126 @@
+# Copyright 2025 Horizon RL Contributors
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tool call parser for Kimi K2 / K2.5 models.
+
+Kimi models use a special-token-based format for tool calls::
+
+    <|tool_calls_section_begin|>
+    <|tool_call_begin|>functions.func_name:0<|tool_call_argument_begin|>{"arg": "val"}<|tool_call_end|>
+    <|tool_calls_section_end|>
+
+The function name is extracted from ``functions.<name>:<index>`` and
+arguments are JSON-encoded.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+
+from typing_extensions import override
+
+from .base import ToolParser, ToolParseResult, register_tool_parser
+
+logger = logging.getLogger(__name__)
+
+
+@register_tool_parser("kimi_k2")
+class KimiK2ToolParser(ToolParser):
+    """Parser for Kimi K2/K2.5 special-token-based tool call format.
+
+    Format:
+        <|tool_calls_section_begin|>
+        <|tool_call_begin|>functions.func_name:0<|tool_call_argument_begin|>{"arg": "val"}<|tool_call_end|>
+        <|tool_calls_section_end|>
+
+    The function name is extracted from the ``functions.<name>:<index>``
+    identifier. Arguments are JSON-encoded dictionaries.
+
+    Think Block Handling:
+        Models with reasoning capabilities may output draft tool calls
+        inside <think>...</think> blocks. These are excluded by default
+        to avoid executing planning/reasoning tool calls.
+
+    Chat Template Notes:
+        Kimi K2 uses no explicit separator between messages.
+    """
+
+    SECTION_PATTERN = re.compile(
+        r"<\|tool_calls_section_begin\|>(.*?)<\|tool_calls_section_end\|>",
+        re.DOTALL,
+    )
+
+    CALL_PATTERN = re.compile(
+        r"<\|tool_call_begin\|>\s*(?P<tool_call_id>[^<\s]+)\s*"
+        r"<\|tool_call_argument_begin\|>\s*(?P<arguments>.*?)\s*"
+        r"<\|tool_call_end\|>",
+        re.DOTALL,
+    )
+
+    @override
+    def parse(self, text: str) -> list[ToolParseResult]:
+        """Parse tool calls from Kimi K2 model output.
+
+        Finds ``<|tool_calls_section_begin|>`` sections, then extracts
+        individual calls with their function names and JSON arguments.
+
+        Args:
+            text: Model output text.
+
+        Returns:
+            List of tool call results (successful and errors).
+        """
+        # Remove think blocks to avoid parsing draft tool calls from reasoning
+        text = self.think_pattern.sub("", text)
+
+        tool_calls: list[ToolParseResult] = []
+        call_index = 0
+
+        for section_match in self.SECTION_PATTERN.finditer(text):
+            section = section_match.group(1)
+
+            for call_match in self.CALL_PATTERN.finditer(section):
+                raw_id = call_match.group("tool_call_id")
+                raw_args = call_match.group("arguments").strip()
+                tool_call_id = f"call_{call_index:04d}"  # Sequential IDs for sortability
+                call_index += 1
+
+                # Extract function name from "functions.func_name:index"
+                # Use split(".", 1) and rsplit(":", 1) to handle dots in names
+                if "." in raw_id:
+                    name = raw_id.split(".", 1)[1].rsplit(":", 1)[0]
+                else:
+                    name = raw_id
+
+                try:
+                    arguments = json.loads(raw_args)
+                    if not isinstance(arguments, dict):
+                        logger.warning("Tool parse error: arguments is not a dict for %s", name)
+                        arguments = {}
+                except json.JSONDecodeError:
+                    logger.warning("Failed to parse arguments for %s: %s", name, raw_args[:200])
+                    tool_calls.append(ToolParseResult.from_parse_error(id=tool_call_id, raw=raw_args, name=name))
+                    continue
+
+                tool_calls.append(
+                    ToolParseResult(
+                        id=tool_call_id,
+                        name=name,
+                        input=arguments,
+                    )
+                )
+
+        return tool_calls

--- a/tests/unit/test_tool_parser.py
+++ b/tests/unit/test_tool_parser.py
@@ -17,8 +17,10 @@
 import pytest
 
 from strands_sglang.tool_parsers import (
+    DeepSeekV32ToolParser,
     GLMToolParser,
     HermesToolParser,
+    KimiK2ToolParser,
     QwenXMLToolParser,
     ToolParseResult,
 )
@@ -1150,6 +1152,670 @@ No, let me reconsider...
         assert results[0].input["limit"] == 5  # JSON-decoded as integer
 
 
+class TestKimiK2ToolParser:
+    """Tests for KimiK2ToolParser (Kimi K2/K2.5 format)."""
+
+    @pytest.fixture
+    def parser(self):
+        """Create a default parser."""
+        return KimiK2ToolParser()
+
+    # --- Basic Parsing ---
+
+    def test_parse_single_tool_call(self, parser):
+        """Parse a single valid tool call."""
+        text = (
+            "<|tool_calls_section_begin|>"
+            "<|tool_call_begin|>functions.calculator:0"
+            '<|tool_call_argument_begin|>{"x": 1, "y": 2}'
+            "<|tool_call_end|>"
+            "<|tool_calls_section_end|>"
+        )
+        results = parser.parse(text)
+
+        assert len(results) == 1
+        assert results[0].name == "calculator"
+        assert results[0].input == {"x": 1, "y": 2}
+        assert results[0].id == "call_0000"
+        assert results[0].is_error is False
+
+    def test_parse_multiple_tool_calls(self, parser):
+        """Parse multiple tool calls in one section."""
+        text = (
+            "<|tool_calls_section_begin|>"
+            "<|tool_call_begin|>functions.tool_a:0"
+            '<|tool_call_argument_begin|>{"a": 1}'
+            "<|tool_call_end|>"
+            "<|tool_call_begin|>functions.tool_b:1"
+            '<|tool_call_argument_begin|>{"b": 2}'
+            "<|tool_call_end|>"
+            "<|tool_calls_section_end|>"
+        )
+        results = parser.parse(text)
+
+        assert len(results) == 2
+        assert results[0].name == "tool_a"
+        assert results[0].input == {"a": 1}
+        assert results[0].id == "call_0000"
+        assert results[1].name == "tool_b"
+        assert results[1].input == {"b": 2}
+        assert results[1].id == "call_0001"
+
+    def test_parse_no_tool_calls(self, parser):
+        """Return empty list when no tool calls present."""
+        text = "Just some regular text without any tool calls."
+        results = parser.parse(text)
+
+        assert len(results) == 0
+
+    def test_parse_empty_string(self, parser):
+        """Handle empty string."""
+        results = parser.parse("")
+        assert len(results) == 0
+
+    def test_parse_with_surrounding_text(self, parser):
+        """Parse tool calls surrounded by regular text."""
+        text = (
+            "I'll help you with that calculation.\n"
+            "<|tool_calls_section_begin|>"
+            "<|tool_call_begin|>functions.calculator:0"
+            '<|tool_call_argument_begin|>{"x": 10, "y": 20}'
+            "<|tool_call_end|>"
+            "<|tool_calls_section_end|>"
+            "\nHere is the result."
+        )
+        results = parser.parse(text)
+
+        assert len(results) == 1
+        assert results[0].name == "calculator"
+        assert results[0].input == {"x": 10, "y": 20}
+
+    # --- Argument Handling ---
+
+    def test_parse_empty_arguments(self, parser):
+        """Tool call with empty arguments object."""
+        text = (
+            "<|tool_calls_section_begin|>"
+            "<|tool_call_begin|>functions.no_args:0"
+            "<|tool_call_argument_begin|>{}"
+            "<|tool_call_end|>"
+            "<|tool_calls_section_end|>"
+        )
+        results = parser.parse(text)
+
+        assert len(results) == 1
+        assert results[0].name == "no_args"
+        assert results[0].input == {}
+        assert results[0].is_error is False
+
+    def test_parse_complex_arguments(self, parser):
+        """Parse complex nested JSON arguments."""
+        text = (
+            "<|tool_calls_section_begin|>"
+            "<|tool_call_begin|>functions.complex_tool:0"
+            '<|tool_call_argument_begin|>{"data": {"nested": [1, 2, 3]}, "flag": true}'
+            "<|tool_call_end|>"
+            "<|tool_calls_section_end|>"
+        )
+        results = parser.parse(text)
+
+        assert len(results) == 1
+        assert results[0].input == {"data": {"nested": [1, 2, 3]}, "flag": True}
+
+    def test_parse_string_arguments(self, parser):
+        """Parse string argument values."""
+        text = (
+            "<|tool_calls_section_begin|>"
+            "<|tool_call_begin|>functions.search:0"
+            '<|tool_call_argument_begin|>{"query": "hello world", "limit": 10}'
+            "<|tool_call_end|>"
+            "<|tool_calls_section_end|>"
+        )
+        results = parser.parse(text)
+
+        assert len(results) == 1
+        assert results[0].input["query"] == "hello world"
+        assert results[0].input["limit"] == 10
+
+    def test_parse_non_dict_arguments_becomes_empty(self, parser):
+        """Non-dict JSON (e.g., array) is replaced with empty dict."""
+        text = (
+            "<|tool_calls_section_begin|>"
+            "<|tool_call_begin|>functions.tool:0"
+            "<|tool_call_argument_begin|>[1, 2, 3]"
+            "<|tool_call_end|>"
+            "<|tool_calls_section_end|>"
+        )
+        results = parser.parse(text)
+
+        assert len(results) == 1
+        assert results[0].input == {}
+        assert results[0].is_error is False
+
+    # --- Function Name Extraction ---
+
+    def test_parse_extracts_name_from_dotted_format(self, parser):
+        """Function name extracted from functions.name:index format."""
+        text = (
+            "<|tool_calls_section_begin|>"
+            "<|tool_call_begin|>functions.my_awesome_tool:0"
+            '<|tool_call_argument_begin|>{"key": "val"}'
+            "<|tool_call_end|>"
+            "<|tool_calls_section_end|>"
+        )
+        results = parser.parse(text)
+
+        assert len(results) == 1
+        assert results[0].name == "my_awesome_tool"
+
+    def test_parse_hyphenated_function_name(self, parser):
+        """Function names with hyphens are parsed correctly."""
+        text = (
+            "<|tool_calls_section_begin|>"
+            "<|tool_call_begin|>functions.web-search:0"
+            '<|tool_call_argument_begin|>{"q": "test"}'
+            "<|tool_call_end|>"
+            "<|tool_calls_section_end|>"
+        )
+        results = parser.parse(text)
+
+        assert len(results) == 1
+        assert results[0].name == "web-search"
+
+    def test_parse_dotted_function_name(self, parser):
+        """Function names with dots are fully preserved."""
+        text = (
+            "<|tool_calls_section_begin|>"
+            "<|tool_call_begin|>functions.module.sub_tool:0"
+            '<|tool_call_argument_begin|>{"x": 1}'
+            "<|tool_call_end|>"
+            "<|tool_calls_section_end|>"
+        )
+        results = parser.parse(text)
+
+        assert len(results) == 1
+        assert results[0].name == "module.sub_tool"
+
+    def test_parse_no_dot_in_id_uses_raw(self, parser):
+        """ID without a dot falls back to using the full raw ID as name."""
+        text = (
+            "<|tool_calls_section_begin|>"
+            "<|tool_call_begin|>calculator:0"
+            '<|tool_call_argument_begin|>{"x": 1}'
+            "<|tool_call_end|>"
+            "<|tool_calls_section_end|>"
+        )
+        results = parser.parse(text)
+
+        assert len(results) == 1
+        assert results[0].name == "calculator:0"
+
+    def test_sequential_ids_generated(self, parser):
+        """IDs are sequential call_NNNN format."""
+        text = (
+            "<|tool_calls_section_begin|>"
+            "<|tool_call_begin|>functions.a:0"
+            '<|tool_call_argument_begin|>{"x": 1}'
+            "<|tool_call_end|>"
+            "<|tool_call_begin|>functions.b:1"
+            '<|tool_call_argument_begin|>{"x": 2}'
+            "<|tool_call_end|>"
+            "<|tool_call_begin|>functions.c:2"
+            '<|tool_call_argument_begin|>{"x": 3}'
+            "<|tool_call_end|>"
+            "<|tool_calls_section_end|>"
+        )
+        results = parser.parse(text)
+
+        assert [r.id for r in results] == ["call_0000", "call_0001", "call_0002"]
+
+    def test_sequential_ids_across_sections(self, parser):
+        """IDs continue incrementing across multiple sections."""
+        text = (
+            "<|tool_calls_section_begin|>"
+            "<|tool_call_begin|>functions.first:0"
+            '<|tool_call_argument_begin|>{"a": 1}'
+            "<|tool_call_end|>"
+            "<|tool_calls_section_end|>"
+            "<|tool_calls_section_begin|>"
+            "<|tool_call_begin|>functions.second:0"
+            '<|tool_call_argument_begin|>{"b": 2}'
+            "<|tool_call_end|>"
+            "<|tool_calls_section_end|>"
+        )
+        results = parser.parse(text)
+
+        assert results[0].id == "call_0000"
+        assert results[1].id == "call_0001"
+
+    # --- Error Cases ---
+
+    def test_parse_malformed_json(self, parser):
+        """Malformed JSON creates error result."""
+        text = (
+            "<|tool_calls_section_begin|>"
+            "<|tool_call_begin|>functions.tool:0"
+            "<|tool_call_argument_begin|>{malformed json}"
+            "<|tool_call_end|>"
+            "<|tool_calls_section_end|>"
+        )
+        results = parser.parse(text)
+
+        assert len(results) == 1
+        assert results[0].is_error is True
+        assert results[0].name == "tool"
+        assert results[0].raw == "{malformed json}"
+
+    def test_parse_truncated_json(self, parser):
+        """Truncated JSON creates error result."""
+        text = (
+            "<|tool_calls_section_begin|>"
+            "<|tool_call_begin|>functions.tool:0"
+            '<|tool_call_argument_begin|>{"key": "val'
+            "<|tool_call_end|>"
+            "<|tool_calls_section_end|>"
+        )
+        results = parser.parse(text)
+
+        assert len(results) == 1
+        assert results[0].is_error is True
+        assert results[0].name == "tool"
+
+    def test_parse_mixed_valid_and_invalid(self, parser):
+        """Valid and invalid calls in same section."""
+        text = (
+            "<|tool_calls_section_begin|>"
+            "<|tool_call_begin|>functions.good:0"
+            '<|tool_call_argument_begin|>{"a": 1}'
+            "<|tool_call_end|>"
+            "<|tool_call_begin|>functions.bad:1"
+            "<|tool_call_argument_begin|>{broken"
+            "<|tool_call_end|>"
+            "<|tool_call_begin|>functions.also_good:2"
+            '<|tool_call_argument_begin|>{"b": 2}'
+            "<|tool_call_end|>"
+            "<|tool_calls_section_end|>"
+        )
+        results = parser.parse(text)
+
+        assert len(results) == 3
+        assert results[0].is_error is False
+        assert results[0].name == "good"
+        assert results[1].is_error is True
+        assert results[1].name == "bad"
+        assert results[2].is_error is False
+        assert results[2].name == "also_good"
+
+    def test_parse_unclosed_section(self, parser):
+        """Unclosed section yields no results."""
+        text = (
+            "<|tool_calls_section_begin|>"
+            "<|tool_call_begin|>functions.tool:0"
+            '<|tool_call_argument_begin|>{"a": 1}'
+            "<|tool_call_end|>"
+        )
+        results = parser.parse(text)
+
+        assert len(results) == 0
+
+    # --- Think Block Handling ---
+
+    def test_parse_ignores_tool_calls_in_think_block(self, parser):
+        """Tool calls inside <think> blocks are excluded."""
+        text = (
+            "<think>Let me think about this...\n"
+            "<|tool_calls_section_begin|>"
+            "<|tool_call_begin|>functions.draft:0"
+            '<|tool_call_argument_begin|>{"a": 1}'
+            "<|tool_call_end|>"
+            "<|tool_calls_section_end|>"
+            "</think>"
+            "<|tool_calls_section_begin|>"
+            "<|tool_call_begin|>functions.real:0"
+            '<|tool_call_argument_begin|>{"b": 2}'
+            "<|tool_call_end|>"
+            "<|tool_calls_section_end|>"
+        )
+        results = parser.parse(text)
+
+        assert len(results) == 1
+        assert results[0].name == "real"
+        assert results[0].input == {"b": 2}
+
+    def test_parse_think_block_only(self, parser):
+        """Only think block tool calls returns empty list."""
+        text = (
+            "<think>"
+            "<|tool_calls_section_begin|>"
+            "<|tool_call_begin|>functions.draft:0"
+            '<|tool_call_argument_begin|>{"a": 1}'
+            "<|tool_call_end|>"
+            "<|tool_calls_section_end|>"
+            "</think>"
+        )
+        results = parser.parse(text)
+
+        assert len(results) == 0
+
+    # --- Whitespace Handling ---
+
+    def test_parse_with_whitespace_in_tokens(self, parser):
+        """Whitespace between tokens is tolerated."""
+        text = (
+            "<|tool_calls_section_begin|>\n"
+            "  <|tool_call_begin|> functions.calculator:0 \n"
+            '  <|tool_call_argument_begin|> {"x": 1} \n'
+            "  <|tool_call_end|>\n"
+            "<|tool_calls_section_end|>"
+        )
+        results = parser.parse(text)
+
+        assert len(results) == 1
+        assert results[0].name == "calculator"
+        assert results[0].input == {"x": 1}
+
+    # --- Multiple Sections ---
+
+    def test_parse_multiple_sections(self, parser):
+        """Parse tool calls from multiple sections."""
+        text = (
+            "<|tool_calls_section_begin|>"
+            "<|tool_call_begin|>functions.first:0"
+            '<|tool_call_argument_begin|>{"a": 1}'
+            "<|tool_call_end|>"
+            "<|tool_calls_section_end|>"
+            "Some text in between"
+            "<|tool_calls_section_begin|>"
+            "<|tool_call_begin|>functions.second:0"
+            '<|tool_call_argument_begin|>{"b": 2}'
+            "<|tool_call_end|>"
+            "<|tool_calls_section_end|>"
+        )
+        results = parser.parse(text)
+
+        assert len(results) == 2
+        assert results[0].name == "first"
+        assert results[1].name == "second"
+
+    # --- Message Separator ---
+
+    def test_message_separator_is_empty(self, parser):
+        """Kimi K2 uses no message separator."""
+        assert parser.message_separator == ""
+
+
+class TestDeepSeekV32ToolParser:
+    """Tests for DeepSeekV32ToolParser (DeepSeek-V3.2 format)."""
+
+    # DSML tag helpers for readable test strings
+    _D = "\uff5cDSML\uff5c"  # ｜DSML｜
+    FC_S = f"<{_D}function_calls>"
+    FC_E = f"</{_D}function_calls>"
+    INV_S = f"<{_D}invoke"  # needs name="..."> appended
+    INV_E = f"</{_D}invoke>"
+    PAR_S = f"<{_D}parameter"  # needs name="..." string="..."> appended
+    PAR_E = f"</{_D}parameter>"
+
+    @pytest.fixture
+    def parser(self):
+        """Create a default parser."""
+        return DeepSeekV32ToolParser()
+
+    def _invoke(self, name, body):
+        """Build an invoke block."""
+        return f'{self.INV_S} name="{name}">\n{body}\n{self.INV_E}'
+
+    def _param(self, name, value, string="false"):
+        """Build a parameter tag."""
+        return f'{self.PAR_S} name="{name}" string="{string}">{value}{self.PAR_E}'
+
+    def _fc(self, *invokes):
+        """Build a function_calls section."""
+        return f"{self.FC_S}\n" + "\n".join(invokes) + f"\n{self.FC_E}"
+
+    # --- Basic Parsing ---
+
+    def test_parse_single_tool_call(self, parser):
+        """Parse a single valid tool call with typed parameters."""
+        text = self._fc(
+            self._invoke("calculator", self._param("x", "1") + "\n" + self._param("y", "2"))
+        )
+        results = parser.parse(text)
+
+        assert len(results) == 1
+        assert results[0].name == "calculator"
+        assert results[0].input == {"x": 1, "y": 2}
+        assert results[0].id == "call_0000"
+        assert results[0].is_error is False
+
+    def test_parse_string_parameter(self, parser):
+        """String parameters with string='true' are kept as-is."""
+        text = self._fc(
+            self._invoke(
+                "search",
+                self._param("query", "hello world", string="true") + "\n" + self._param("limit", "10"),
+            )
+        )
+        results = parser.parse(text)
+
+        assert len(results) == 1
+        assert results[0].input["query"] == "hello world"
+        assert results[0].input["limit"] == 10
+
+    def test_parse_multiple_tool_calls(self, parser):
+        """Parse multiple invoke blocks in one function_calls section."""
+        text = self._fc(
+            self._invoke("tool_a", self._param("a", "1")),
+            self._invoke("tool_b", self._param("b", "hello", string="true")),
+        )
+        results = parser.parse(text)
+
+        assert len(results) == 2
+        assert results[0].name == "tool_a"
+        assert results[0].input == {"a": 1}
+        assert results[0].id == "call_0000"
+        assert results[1].name == "tool_b"
+        assert results[1].input == {"b": "hello"}
+        assert results[1].id == "call_0001"
+
+    def test_parse_no_tool_calls(self, parser):
+        """Return empty list when no tool calls present."""
+        text = "Just some regular text without any tool calls."
+        results = parser.parse(text)
+
+        assert len(results) == 0
+
+    def test_parse_empty_string(self, parser):
+        """Handle empty string."""
+        results = parser.parse("")
+        assert len(results) == 0
+
+    def test_parse_with_surrounding_text(self, parser):
+        """Parse tool calls surrounded by regular text."""
+        text = "Let me calculate that for you.\n" + self._fc(
+            self._invoke("calculator", self._param("x", "42"))
+        ) + "\nHere is the result."
+        results = parser.parse(text)
+
+        assert len(results) == 1
+        assert results[0].name == "calculator"
+        assert results[0].input == {"x": 42}
+
+    # --- Parameter Type Handling ---
+
+    def test_parse_boolean_parameter(self, parser):
+        """Non-string boolean parameter is JSON-decoded."""
+        text = self._fc(self._invoke("config", self._param("verbose", "true")))
+        results = parser.parse(text)
+
+        assert len(results) == 1
+        assert results[0].input["verbose"] is True
+
+    def test_parse_list_parameter(self, parser):
+        """Non-string list parameter is JSON-decoded."""
+        text = self._fc(self._invoke("batch", self._param("items", "[1, 2, 3]")))
+        results = parser.parse(text)
+
+        assert len(results) == 1
+        assert results[0].input["items"] == [1, 2, 3]
+
+    def test_parse_object_parameter(self, parser):
+        """Non-string object parameter is JSON-decoded."""
+        text = self._fc(self._invoke("update", self._param("data", '{"key": "val"}')))
+        results = parser.parse(text)
+
+        assert len(results) == 1
+        assert results[0].input["data"] == {"key": "val"}
+
+    def test_parse_non_string_invalid_json_falls_back_to_string(self, parser):
+        """Non-string parameter with invalid JSON falls back to raw string."""
+        text = self._fc(self._invoke("tool", self._param("val", "not json")))
+        results = parser.parse(text)
+
+        assert len(results) == 1
+        assert results[0].input["val"] == "not json"
+
+    def test_parse_no_parameters(self, parser):
+        """Invoke with no parameters yields empty arguments."""
+        text = self._fc(self._invoke("no_args", ""))
+        results = parser.parse(text)
+
+        assert len(results) == 1
+        assert results[0].name == "no_args"
+        assert results[0].input == {}
+        assert results[0].is_error is False
+
+    # --- JSON Fallback ---
+
+    def test_parse_json_fallback(self, parser):
+        """When no parameter tags, try parsing invoke body as JSON."""
+        text = self._fc(self._invoke("calculator", '{"x": 1, "y": 2}'))
+        results = parser.parse(text)
+
+        assert len(results) == 1
+        assert results[0].name == "calculator"
+        assert results[0].input == {"x": 1, "y": 2}
+        assert results[0].is_error is False
+
+    def test_parse_json_fallback_non_dict_becomes_empty(self, parser):
+        """JSON fallback with non-dict value becomes empty arguments."""
+        text = self._fc(self._invoke("tool", "[1, 2, 3]"))
+        results = parser.parse(text)
+
+        assert len(results) == 1
+        assert results[0].input == {}
+        assert results[0].is_error is False
+
+    def test_parse_json_fallback_invalid_json_error(self, parser):
+        """JSON fallback with invalid JSON creates error result."""
+        text = self._fc(self._invoke("tool", "this is not json"))
+        results = parser.parse(text)
+
+        assert len(results) == 1
+        assert results[0].is_error is True
+        assert results[0].name == "tool"
+
+    # --- Error Cases ---
+
+    def test_parse_mixed_valid_and_invalid(self, parser):
+        """Valid and invalid calls in same section."""
+        text = self._fc(
+            self._invoke("good", self._param("a", "1")),
+            self._invoke("bad", "broken content"),
+            self._invoke("also_good", self._param("b", "2")),
+        )
+        results = parser.parse(text)
+
+        assert len(results) == 3
+        assert results[0].is_error is False
+        assert results[0].name == "good"
+        assert results[1].is_error is True
+        assert results[1].name == "bad"
+        assert results[2].is_error is False
+        assert results[2].name == "also_good"
+
+    def test_parse_unclosed_function_calls(self, parser):
+        """Unclosed function_calls yields no results."""
+        text = self.FC_S + "\n" + self._invoke("tool", self._param("x", "1"))
+        results = parser.parse(text)
+
+        assert len(results) == 0
+
+    # --- Think Block Handling ---
+
+    def test_parse_ignores_tool_calls_in_think_block(self, parser):
+        """Tool calls inside <think> blocks are excluded."""
+        draft = self._fc(self._invoke("draft", self._param("a", "1")))
+        real = self._fc(self._invoke("real", self._param("b", "2")))
+        text = f"<think>Let me think...\n{draft}\n</think>\n{real}"
+        results = parser.parse(text)
+
+        assert len(results) == 1
+        assert results[0].name == "real"
+        assert results[0].input == {"b": 2}
+
+    def test_parse_think_block_only(self, parser):
+        """Only think block tool calls returns empty list."""
+        draft = self._fc(self._invoke("draft", self._param("a", "1")))
+        text = f"<think>\n{draft}\n</think>"
+        results = parser.parse(text)
+
+        assert len(results) == 0
+
+    # --- Sequential IDs ---
+
+    def test_sequential_ids_generated(self, parser):
+        """IDs are sequential call_NNNN format."""
+        text = self._fc(
+            self._invoke("a", self._param("x", "1")),
+            self._invoke("b", self._param("x", "2")),
+            self._invoke("c", self._param("x", "3")),
+        )
+        results = parser.parse(text)
+
+        assert [r.id for r in results] == ["call_0000", "call_0001", "call_0002"]
+
+    def test_sequential_ids_across_sections(self, parser):
+        """IDs continue incrementing across multiple function_calls sections."""
+        s1 = self._fc(self._invoke("first", self._param("a", "1")))
+        s2 = self._fc(self._invoke("second", self._param("b", "2")))
+        text = f"{s1}\ntext in between\n{s2}"
+        results = parser.parse(text)
+
+        assert results[0].id == "call_0000"
+        assert results[1].id == "call_0001"
+
+    # --- Custom Tokens ---
+
+    def test_default_tool_tokens(self, parser):
+        """Default tool tokens are DSML-prefixed function_calls tags."""
+        assert "\uff5cDSML\uff5c" in parser.tool_start_token
+        assert "function_calls" in parser.tool_start_token
+        assert "\uff5cDSML\uff5c" in parser.tool_end_token
+
+    def test_custom_think_tokens(self):
+        """Custom think tokens are respected."""
+        parser = DeepSeekV32ToolParser(think_start_token="<reasoning>", think_end_token="</reasoning>")
+        draft = self._fc(self._invoke("draft", self._param("a", "1")))
+        real = self._fc(self._invoke("real", self._param("b", "2")))
+        text = f"<reasoning>draft\n{draft}\n</reasoning>\n{real}"
+        results = parser.parse(text)
+
+        assert len(results) == 1
+        assert results[0].name == "real"
+
+    # --- Message Separator ---
+
+    def test_message_separator_is_eos_token(self, parser):
+        """DeepSeek-V3.2 uses special EOS token as message separator."""
+        sep = parser.message_separator
+        assert "\uff5c" in sep  # fullwidth pipe
+        assert "\u2581" in sep  # half-width space
+        assert "end" in sep
+        assert "of" in sep
+        assert "sentence" in sep
+
+
 class TestToolParserRegistry:
     """Tests for tool parser registry."""
 
@@ -1208,3 +1874,287 @@ class TestToolParserRegistry:
 
         assert "glm" in TOOL_PARSER_REGISTRY
         assert TOOL_PARSER_REGISTRY["glm"] is GLMToolParser
+
+    def test_get_kimi_k2_parser(self):
+        """Get kimi_k2 parser by name."""
+        from strands_sglang.tool_parsers import get_tool_parser
+
+        parser = get_tool_parser("kimi_k2")
+        assert isinstance(parser, KimiK2ToolParser)
+
+    def test_registry_contains_kimi_k2(self):
+        """Registry contains kimi_k2 parser."""
+        from strands_sglang.tool_parsers import TOOL_PARSER_REGISTRY
+
+        assert "kimi_k2" in TOOL_PARSER_REGISTRY
+        assert TOOL_PARSER_REGISTRY["kimi_k2"] is KimiK2ToolParser
+
+    def test_get_deepseek_v32_parser(self):
+        """Get deepseek_v32 parser by name."""
+        from strands_sglang.tool_parsers import get_tool_parser
+
+        parser = get_tool_parser("deepseek_v32")
+        assert isinstance(parser, DeepSeekV32ToolParser)
+
+    def test_registry_contains_deepseek_v32(self):
+        """Registry contains deepseek_v32 parser."""
+        from strands_sglang.tool_parsers import TOOL_PARSER_REGISTRY
+
+        assert "deepseek_v32" in TOOL_PARSER_REGISTRY
+        assert TOOL_PARSER_REGISTRY["deepseek_v32"] is DeepSeekV32ToolParser
+
+
+class TestDeepSeekV32FormatPrompt:
+    """Tests for DeepSeekV32ToolParser.format_prompt.
+
+    The default constructor auto-downloads encoding_dsv32.py from HuggingFace.
+    Module-delegation tests use a mock encoding module.
+    """
+
+    @pytest.fixture
+    def parser(self):
+        return DeepSeekV32ToolParser()
+
+    def test_default_loads_encoding_module(self, parser):
+        """Default constructor loads encoding module from deepseek-ai/DeepSeek-V3.2."""
+        assert parser._encoding_module is not None
+        messages = [{"role": "user", "content": "hello"}]
+        result = parser.format_prompt(messages)
+        assert result is not None
+        assert isinstance(result, str)
+
+    def test_base_parser_returns_none(self):
+        """Base ToolParser.format_prompt returns None."""
+        result = HermesToolParser().format_prompt([{"role": "user", "content": "hi"}])
+        assert result is None
+
+    def test_delegates_to_encoding_module(self):
+        """When encoding module is loaded, format_prompt delegates to it."""
+        parser = DeepSeekV32ToolParser()
+
+        # Mock encoding module with minimal encode_messages and render_tools
+        import types
+
+        mock_mod = types.ModuleType("encoding_dsv32")
+        mock_mod.encode_messages = lambda messages, thinking_mode: f"encoded:{thinking_mode}"
+        parser._encoding_module = mock_mod
+
+        messages = [{"role": "user", "content": "hello"}]
+        result = parser.format_prompt(messages)
+        assert result == "encoded:chat"
+
+    def test_delegates_with_thinking_mode(self):
+        """Thinking mode is passed through to the encoding module."""
+        parser = DeepSeekV32ToolParser()
+
+        import types
+
+        mock_mod = types.ModuleType("encoding_dsv32")
+        mock_mod.encode_messages = lambda messages, thinking_mode: f"encoded:{thinking_mode}"
+        parser._encoding_module = mock_mod
+
+        result = parser.format_prompt([{"role": "user", "content": "hi"}], enable_thinking=True)
+        assert result == "encoded:thinking"
+
+    def test_delegates_with_tools(self):
+        """Tools are attached to system message before delegating."""
+        parser = DeepSeekV32ToolParser()
+
+        import types
+
+        mock_mod = types.ModuleType("encoding_dsv32")
+        captured = {}
+
+        def mock_encode(messages, thinking_mode):
+            captured["messages"] = messages
+            return "encoded"
+
+        mock_mod.encode_messages = mock_encode
+        parser._encoding_module = mock_mod
+
+        messages = [
+            {"role": "system", "content": "System prompt."},
+            {"role": "user", "content": "hi"},
+        ]
+        tools = [{"type": "function", "function": {"name": "search", "description": "Search", "parameters": {}}}]
+
+        result = parser.format_prompt(messages, tools=tools)
+        assert result == "encoded"
+        # Tools should be attached to system message for the encoding module to handle
+        assert captured["messages"][0]["tools"] == tools
+
+    def test_tools_creates_system_message_if_missing(self):
+        """When no system message exists, tools create a synthetic one."""
+        parser = DeepSeekV32ToolParser()
+
+        import types
+
+        mock_mod = types.ModuleType("encoding_dsv32")
+        captured = {}
+
+        def mock_encode(messages, thinking_mode):
+            captured["messages"] = messages
+            return "encoded"
+
+        mock_mod.encode_messages = mock_encode
+        parser._encoding_module = mock_mod
+
+        messages = [{"role": "user", "content": "hi"}]
+        tools = [{"type": "function", "function": {"name": "f", "description": "d", "parameters": {}}}]
+
+        parser.format_prompt(messages, tools=tools)
+        assert captured["messages"][0]["role"] == "system"
+        assert captured["messages"][0]["tools"] == tools
+        assert captured["messages"][1]["role"] == "user"
+
+    def test_format_prompt_does_not_mutate_messages(self):
+        """format_prompt does not modify the input message list."""
+        parser = DeepSeekV32ToolParser()
+
+        import types
+
+        mock_mod = types.ModuleType("encoding_dsv32")
+        mock_mod.encode_messages = lambda messages, thinking_mode: "encoded"
+        parser._encoding_module = mock_mod
+
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "hi"},
+        ]
+        tools = [{"type": "function", "function": {"name": "f", "description": "d", "parameters": {}}}]
+        parser.format_prompt(messages, tools=tools)
+        assert "tools" not in messages[0]
+        assert messages[0]["content"] == "sys"
+        assert len(messages) == 2
+
+    def test_load_encoding_module_file_not_found(self, tmp_path):
+        """Loading from a local path without encoding file raises FileNotFoundError."""
+        with pytest.raises(FileNotFoundError, match="Encoding file not found"):
+            DeepSeekV32ToolParser(model_name_or_path=str(tmp_path))
+
+    def test_load_encoding_module_local_path(self, tmp_path):
+        """Loading from a local path with encoding file succeeds."""
+        encoding_dir = tmp_path / "encoding"
+        encoding_dir.mkdir()
+        encoding_file = encoding_dir / "encoding_dsv32.py"
+        encoding_file.write_text(
+            "def encode_messages(messages, thinking_mode): return 'local'\n"
+            "def render_tools(tools): return 'tools'\n"
+        )
+        parser = DeepSeekV32ToolParser(model_name_or_path=str(tmp_path))
+        assert parser._encoding_module is not None
+        result = parser.format_prompt([{"role": "user", "content": "hi"}])
+        assert result == "local"
+
+    @pytest.mark.parametrize("thinking_mode", [False, True])
+    def test_load_real_encoding_module(self, thinking_mode):
+        """Load the real encoding_dsv32.py from deepseek-ai/DeepSeek-V3.2.
+
+        Verifies format_prompt produces exactly the same output as calling
+        the reference module directly.
+        """
+        parser = DeepSeekV32ToolParser(model_name_or_path="deepseek-ai/DeepSeek-V3.2")
+        assert parser._encoding_module is not None
+
+        # Verify the module has the expected interface
+        mod = parser._encoding_module
+        assert hasattr(mod, "encode_messages")
+        assert hasattr(mod, "render_tools")
+        assert callable(mod.encode_messages)
+        assert callable(mod.render_tools)
+
+        # Test format_prompt with a multi-turn conversation including tool calls
+        messages = [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "What is the weather?"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "get_weather",
+                            "arguments": '{"city": "London"}',
+                        },
+                    }
+                ],
+            },
+            {"role": "tool", "content": "Sunny, 22C"},
+            {"role": "user", "content": "Thanks!"},
+        ]
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "description": "Get weather for a city",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"city": {"type": "string"}},
+                    },
+                },
+            }
+        ]
+        thinking_mode_str = "thinking" if thinking_mode else "chat"
+        result = parser.format_prompt(messages, tools=tools, enable_thinking=thinking_mode)
+
+        # Build expected output by calling the reference module directly
+        # (same steps as format_prompt: attach tools to system message, then encode)
+        import copy
+
+        expected_messages = copy.deepcopy(messages)
+        expected_messages[0]["tools"] = tools
+        expected = mod.encode_messages(expected_messages, thinking_mode=thinking_mode_str)
+
+        assert result == expected
+
+        # Roundtrip: tool calls encoded by format_prompt can be parsed back.
+        # The system prompt's tool documentation also contains example invoke
+        # blocks (with $FUNCTION_NAME placeholders), so filter for real calls.
+        parsed = parser.parse(result)
+        real_calls = [p for p in parsed if not p.is_error]
+        assert len(real_calls) == 1
+        assert real_calls[0].name == "get_weather"
+        assert real_calls[0].input["city"] == "London"
+
+    def test_format_incremental_tool_results(self, parser):
+        """Tool-result-only messages use _format_incremental instead of encode_messages."""
+        messages = [
+            {"role": "tool", "content": "Sunny, 22C"},
+            {"role": "tool", "content": "Rainy, 15C"},
+        ]
+        result = parser.format_prompt(messages)
+        assert result is not None
+        assert "<function_results>" in result
+        assert "</function_results>" in result
+        assert "<result>Sunny, 22C</result>" in result
+        assert "<result>Rainy, 15C</result>" in result
+        # Default: chat mode → </think> generation prompt
+        assert result.endswith("\n\n</think>")
+
+    def test_format_incremental_single_result(self, parser):
+        """Single tool result is formatted correctly with generation prompt."""
+        messages = [{"role": "tool", "content": "42"}]
+        result = parser.format_prompt(messages)
+        assert result == "\n\n<function_results>\n<result>42</result>\n</function_results>\n\n</think>"
+
+    def test_format_incremental_thinking_mode(self, parser):
+        """Incremental format uses <think> generation prompt in thinking mode."""
+        messages = [{"role": "tool", "content": "42"}]
+        result = parser.format_prompt(messages, enable_thinking=True)
+        assert result.endswith("\n\n<think>")
+
+    def test_format_incremental_no_generation_prompt(self, parser):
+        """Incremental format omits generation prompt when add_generation_prompt=False."""
+        messages = [{"role": "tool", "content": "42"}]
+        result = parser.format_prompt(messages, add_generation_prompt=False)
+        assert result == "\n\n<function_results>\n<result>42</result>\n</function_results>"
+
+    def test_skip_special_tokens_is_false(self, parser):
+        """DeepSeekV32ToolParser requires special tokens preserved."""
+        assert parser.skip_special_tokens is False
+
+    def test_base_skip_special_tokens_is_true(self):
+        """Base ToolParser defaults to skip_special_tokens=True."""
+        assert HermesToolParser().skip_special_tokens is True


### PR DESCRIPTION
## Summary

- Add `KimiK2ToolParser` for Kimi K2/K2.5 special-token-based tool call format (`<|tool_calls_section_begin|>` sections)
- Add `DeepSeekV32ToolParser` for DeepSeek-V3.2 DSML-prefixed XML format (`｜DSML｜` tags with typed `string="true/false"` parameters)
- Add `format_prompt()` to `ToolParser` base class for models without Jinja chat templates; `DeepSeekV32ToolParser` loads the model's `encoding/encoding_dsv32.py` via `huggingface_hub` and delegates to it
- Add `skip_special_tokens` class attribute to `ToolParser` so parsers can control whether special tokens are preserved during decoding for tool parsing
- Add `_format_incremental()` to `DeepSeekV32ToolParser` for formatting tool results on subsequent turns without requiring the full conversation history
- Update `SGLangModel.format_prompt` to try the parser's `format_prompt` first, falling back to `tokenizer.apply_chat_template()` when it returns `None`
- Update `SGLangModel.stream` to decode `output_ids` locally using the parser's `skip_special_tokens` flag for tool parsing