### PR TITLE
refactor: remove _current_tools state

### DIFF
--- a/src/strands_sglang/sglang.py
+++ b/src/strands_sglang/sglang.py
@@ -112,7 +112,6 @@ class SGLangModel(Model):
         # State tracking (this makes SGLangModel stateful)
         self.token_manager = TokenManager()
         self._processed_message_count: int = 0
-        self._current_tools: list[dict] | None = None
         self.tool_parse_errors: dict[str, int] = {}  # per-tool parse error count
 
         logger.debug(f"initialized with config: {self.config}")
@@ -125,7 +124,6 @@ class SGLangModel(Model):
         """
         self.token_manager.reset()
         self._processed_message_count = 0
-        self._current_tools = None
         self.tool_parse_errors = {}
 
     # -------------------------------------------------------------------------
@@ -266,6 +264,7 @@ class SGLangModel(Model):
         self,
         messages: Messages,
         system_prompt: str | None,
+        tool_specs: list[dict] | None = None,
     ) -> list[int] | None:
         """Tokenize prompt messages for the next generation call.
 
@@ -275,7 +274,7 @@ class SGLangModel(Model):
         """
         # First call: full prompt with tools
         if len(self.token_manager) == 0:
-            formatted = self.format_prompt(messages, system_prompt, tools=self._current_tools)
+            formatted = self.format_prompt(messages, system_prompt, tools=tool_specs)
             return self.tokenizer.encode(formatted, add_special_tokens=False)
 
         # Subsequent calls: only new messages
@@ -366,16 +365,12 @@ class SGLangModel(Model):
         The `stream` method follows Strands' protocol but actually disabled here for training-only usage.
         This means users won't see streaming behavior such as print callbacks.
         """
-        # Format tools (only on first call)
-        if tool_specs and not self._current_tools:
-            self._current_tools = self.format_tool_specs(tool_specs)
-            logger.debug(f"tools formatted: {len(self._current_tools)} tools")
-
         # Prepare request
+        formatted_tools = self.format_tool_specs(tool_specs) if tool_specs else None
         config = self.get_config()
         sampling_params: dict[str, Any] = dict(config.get("sampling_params") or {})
         return_logprob = config.get("return_logprob", True)
-        new_input_tokens = self.tokenize_prompt_messages(messages, system_prompt)
+        new_input_tokens = self.tokenize_prompt_messages(messages, system_prompt, tool_specs=formatted_tools)
         # Tracking token IDs in token_manager to ensure the token-in feature
         input_ids = self.token_manager.token_ids + (new_input_tokens or [])
 

--- a/tests/unit/test_sglang.py
+++ b/tests/unit/test_sglang.py
@@ -123,9 +123,9 @@ class TestTokenizePromptMessages:
     def test_first_call_tokenizes_full_prompt(self, model, mock_tokenizer):
         """First call tokenizes full prompt with system and tools."""
         messages = [{"role": "user", "content": [{"text": "Hello"}]}]
-        model._current_tools = [{"type": "function", "function": {"name": "test"}}]
+        tools = [{"type": "function", "function": {"name": "test"}}]
 
-        result = model.tokenize_prompt_messages(messages, system_prompt="Be helpful.")
+        result = model.tokenize_prompt_messages(messages, system_prompt="Be helpful.", tool_specs=tools)
 
         assert result == [1, 2, 3, 4, 5]
         mock_tokenizer.encode.assert_called_once()
@@ -277,13 +277,13 @@ class TestReset:
 
         assert model._processed_message_count == 0
 
-    def test_reset_clears_tools(self, model):
-        """Reset clears current tools."""
-        model._current_tools = [{"type": "function"}]
+    def test_reset_clears_parse_errors(self, model):
+        """Reset clears tool parse error counts."""
+        model.tool_parse_errors = {"broken_tool": 3}
 
         model.reset()
 
-        assert model._current_tools is None
+        assert model.tool_parse_errors == {}
 
 
 class TestConfig:


### PR DESCRIPTION
## Summary
- Remove `_current_tools` mutable state from `SGLangModel.__init__` and `reset()`
- Pass formatted tool specs as a parameter to `tokenize_prompt_messages` instead of caching
- `format_tool_specs` is trivially cheap (dict restructuring), no reason to cache

## Test plan
- [x] All 246 unit tests pass
- [x] All 65 integration tests pass
- [x] Lint clean (ruff check + format)

🤖 Generated with [Claude Code](https://claude.com/claude-code)