### PR TITLE
feat: add VLM (Vision Language Model) support with TITO

### DIFF
--- a/.claude/commands/run-integration-tests.md
+++ b/.claude/commands/run-integration-tests.md
@@ -6,10 +6,17 @@ Integration tests require a running SGLang server. Before running any commands, 
    - `http://localhost:30000` (default — assumes local or SSH-tunneled server)
    - Let the user provide a custom URL
 
+2. "Include VLM tests?" — offer these options:
+   - No (default — skip VLM tests, no torch needed)
+   - Yes (install torch + torchvision CPU for VLM processor tokenization)
+
 Then proceed:
 
 1. Create a temporary venv at `/tmp/strands-sglang-test-venv` using `uv venv /tmp/strands-sglang-test-venv --python 3.12 -q`
 2. Install the package with dev dependencies: `uv pip install -e ".[dev]" --python /tmp/strands-sglang-test-venv/bin/python -q`
-3. Run integration tests with the confirmed URL: `/tmp/strands-sglang-test-venv/bin/python -m pytest tests/integration/ -v --tb=short --sglang-base-url=<URL> $ARGUMENTS`
+3. If VLM tests requested, install torch CPU: `uv pip install torch torchvision --index-url https://download.pytorch.org/whl/cpu --python /tmp/strands-sglang-test-venv/bin/python -q`
+4. Run integration tests with the confirmed URL: `/tmp/strands-sglang-test-venv/bin/python -m pytest tests/integration/ -v --tb=short --sglang-base-url=<URL> $ARGUMENTS`
+
+Note: VLM integration tests are automatically skipped if the server is running a text-only model or if torch is not installed, so it's safe to always run the full test suite.
 
 IMPORTANT: Never use the active shell's python/pytest — it may point to a different venv. Always use the temporary venv's python.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,11 +43,11 @@ pytest tests/integration/ -v --sglang-base-url=http://localhost:30000
 
 The package lives in `src/strands_sglang/` with 7 core modules:
 
-**SGLangModel** (`sglang.py`) - Main entry point implementing the Strands `Model` interface. Requires `client` and `tokenizer` (all keyword-only). Formats messages using HuggingFace chat templates (`apply_chat_template()`), calls SGLang's `/generate` endpoint (non-streaming by design for RL throughput), tracks TITO trajectory, and parses tool calls. Configuration via `SGLangConfig` TypedDict (sampling_params, return_logprob, enable_thinking).
+**SGLangModel** (`sglang.py`) - Main entry point implementing the Strands `Model` interface. Requires `client` and either `tokenizer` or `processor` (all keyword-only). Formats messages using HuggingFace chat templates (`apply_chat_template()`), calls SGLang's `/generate` endpoint (non-streaming by design for RL throughput), tracks TITO trajectory, and parses tool calls. When `processor` is provided (VLM mode), uses `processor(text, images)` for tokenization and accumulates `image_data` (base64 data URLs) for SGLang. Configuration via `SGLangConfig` TypedDict (sampling_params, return_logprob, enable_thinking).
 
 **SGLangClient** (`client.py`) - Async HTTP client using aiohttp with connection pooling and aggressive retry (60 attempts by default, aligned with SLIME RL framework). All error classification is centralized in `_classify_http_error()`, which maps HTTP responses to custom exceptions (`SGLangContextLengthError`, `SGLangThrottledError`, etc.). Non-retryable errors: 401, 403, 404, context-length 400. Uses lazy session creation to avoid aiohttp's event-loop warnings.
 
-**Utilities** (`utils.py`) - `lru_cache`-backed factories for shared client and tokenizer instances: `get_client()`, `get_client_from_slime_args()`, `get_tokenizer()`. Ensures connection pooling and tokenizer reuse across RL workers without explicit lifecycle management.
+**Utilities** (`utils.py`) - `lru_cache`-backed factories for shared client and tokenizer instances: `get_client()`, `get_client_from_slime_args()`, `get_tokenizer()`, `get_processor()`. Ensures connection pooling and tokenizer/processor reuse across RL workers without explicit lifecycle management.
 
 **Exceptions** (`exceptions.py`) - Custom exception hierarchy rooted at `SGLangClientError`. HTTP errors are classified into `SGLangHTTPError` (base), `SGLangContextLengthError` (400 + length patterns), and `SGLangThrottledError` (429/503). Connection failures become `SGLangConnectionError`, non-JSON responses become `SGLangDecodingError`. These exceptions form the contract between `client.py` and `sglang.py` — the model layer never inspects raw HTTP status codes.
 
@@ -63,6 +63,7 @@ The package lives in `src/strands_sglang/` with 7 core modules:
 - **Incremental tokenization**: First call tokenizes full prompt; subsequent calls only tokenize new messages (tool results) with message separator prepended
 - **Strict tool parsing for RL**: No heuristic repair of malformed tool calls; errors propagated to model for self-correction
 - **Segment-based TITO**: Token tracking mirrors multi-turn structure (prompt=no loss, response=loss)
+- **VLM via processor**: When `processor` is provided, tokenization switches from `tokenizer.encode(text)` to `processor(text, images)["input_ids"][0]` (unwrapping batch dimension). Images are accumulated as base64 data URLs and forwarded to SGLang's `image_data` parameter. `torch` and `torchvision` are not pinned as dependencies — users install them separately to match their CUDA version
 
 ## Code Style
 
@@ -84,3 +85,17 @@ pytest tests/integration/ -v --sglang-base-url=http://localhost:30000
 ```
 
 Test with both an instruct model (e.g., `Qwen3-4B-Instruct-2507`) and a thinking model (e.g., `Qwen3-8B`) for full coverage. Thinking models will skip `MessageToTokenDrift` tests (expected).
+
+### VLM Integration Tests
+
+VLM tests require an SGLang server running a VLM model (e.g., `Qwen/Qwen3-VL-4B-Instruct`) and `torch` + `torchvision` installed in the test environment. Tests are automatically skipped when:
+- The server is running a text-only model (no `ProcessorMixin` detected)
+- `torch`/`torchvision` are not installed (`AutoProcessor` raises `ImportError`)
+
+```bash
+# Install VLM dependencies in test venv (CPU is sufficient for tokenization)
+pip install torch torchvision --index-url https://download.pytorch.org/whl/cpu
+
+# Run VLM tests specifically
+pytest tests/integration/test_vlm_integration.py -v --sglang-base-url=http://localhost:30000
+```

--- a/examples/vlm_agent/README.md
+++ b/examples/vlm_agent/README.md
@@ -1,0 +1,56 @@
+# VLM Agent with Inline Image + Image-Returning Tool
+
+This example demonstrates two ways images enter the strands-sglang VLM pipeline:
+
+1. **Inline in user prompt** — a.jpg is embedded directly in the initial message
+2. **Via tool result** — the agent calls `read_image("b.jpg")` to load the second image
+
+## How It Works
+
+```
+User message: [a.jpg IMAGE] "This is a.jpg. Use read_image to load b.jpg. Describe both."
+  │
+  ▼  tokenize_prompt_messages() — first turn
+  │  processor(text, images=[a_pil]) → input_ids with vision tokens for a.jpg
+  │  image_data = [a_b64]
+  ▼
+Model generates: <tool_call>{"name": "read_image", "arguments": {"file_path": "b.jpg"}}</tool_call>
+  │
+  ▼  Tool reads b.jpg from disk → returns {"image": "data:image/jpeg;base64,..."}
+  │
+  ▼  tokenize_prompt_messages() — incremental (tool result only)
+  │  processor(text, images=[a_b64, b_b64]) → input_ids with vision tokens for b.jpg
+  │  image_data = [a_b64, b_b64]  (accumulated)
+  ▼
+Model generates final response with both images in context
+  │  SGLang payload: {input_ids: [...], image_data: [a_b64, b_b64]}
+  ▼
+TITO state:
+  segment[0]: PROMPT    — system + tools + user message with a.jpg vision tokens
+  segment[1]: RESPONSE  — model output with tool call
+  segment[2]: PROMPT    — tool result with b.jpg vision tokens
+  segment[3]: RESPONSE  — final description of both images
+```
+
+The example also shows how to extract multimodal training tensors (`pixel_values`, `image_grid_thw`) from the HF processor for RL training pipelines — this is outside strands-sglang's scope but commonly needed alongside the TITO trajectory.
+
+## Setup
+
+```bash
+# 1. Install strands-sglang with VLM dependencies
+pip install -e ".[vision]"
+pip install torch torchvision  # install separately to match your CUDA version
+
+# 2. Download sample images
+curl -Lo examples/vlm_agent/images/a.jpg "https://upload.wikimedia.org/wikipedia/commons/thumb/3/34/Labrador_on_Quantock_%282175262184%29.jpg/500px-Labrador_on_Quantock_%282175262184%29.jpg"
+curl -Lo examples/vlm_agent/images/b.jpg "https://upload.wikimedia.org/wikipedia/commons/thumb/1/1a/Orange_tabby_kitten.jpg/500px-Orange_tabby_kitten.jpg"
+
+# 3. Launch SGLang with a VLM model
+python -m sglang.launch_server \
+    --model-path Qwen/Qwen3-VL-4B-Instruct \
+    --port 30000
+
+# 4. Run the example
+python examples/vlm_agent/vlm_agent.py
+# Configure via env vars: SGLANG_BASE_URL, MODEL_PATH
+```

--- a/examples/vlm_agent/images/.gitignore
+++ b/examples/vlm_agent/images/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/examples/vlm_agent/vlm_agent.py
+++ b/examples/vlm_agent/vlm_agent.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+# Copyright 2025 Horizon RL Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""VLM agent example with inline image and image-returning tool.
+
+Demonstrates two ways images enter the strands-sglang VLM pipeline:
+
+1. **Inline in user prompt** — a.jpg is embedded directly in the initial message
+2. **Via tool result** — the agent calls ``read_image("b.jpg")`` to load the second image
+
+After the agent finishes, we inspect TITO trajectory and show how to extract
+multimodal training tensors (pixel_values, image_grid_thw) from the HF processor
+for RL training pipelines.
+
+Usage:
+    python examples/vlm_agent/vlm_agent.py
+    # Configure via env vars: SGLANG_BASE_URL, MODEL_PATH
+"""
+
+import asyncio
+import base64
+import json
+import os
+from pathlib import Path
+
+from strands import Agent, tool
+from transformers import AutoProcessor
+
+from strands_sglang import SGLangModel, ToolLimiter
+from strands_sglang.client import SGLangClient
+from strands_sglang.tool_parsers import HermesToolParser
+
+IMAGE_DIR = Path(__file__).parent / "images"
+
+
+@tool
+def read_image(file_path: str) -> dict:
+    """Read an image file and return it for visual inspection.
+
+    Args:
+        file_path: Filename of the image (e.g., "a.jpg", "b.png").
+    """
+    path = Path(file_path)
+    if not path.exists():
+        path = IMAGE_DIR / path.name
+
+    if not path.exists():
+        return {
+            "status": "error",
+            "content": [{"text": f"File not found: {path}"}],
+        }
+
+    image_bytes = path.read_bytes()
+    suffix = path.suffix.lower().lstrip(".")
+    fmt = {"jpg": "jpeg", "jpeg": "jpeg", "png": "png", "gif": "gif", "webp": "webp"}.get(suffix, "png")
+
+    return {
+        "status": "success",
+        "content": [
+            {"text": f"Image loaded: {path.name} ({len(image_bytes)} bytes)"},
+            {"image": {"format": fmt, "source": {"bytes": image_bytes}}},
+        ],
+    }
+
+
+def _summarize_for_display(obj):
+    """Make trajectory JSON-serializable with truncated binary data."""
+    if isinstance(obj, bytes):
+        return f"<{len(obj)} bytes>"
+    if isinstance(obj, dict):
+        return {k: _summarize_for_display(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_summarize_for_display(v) for v in obj]
+    if isinstance(obj, str) and obj.startswith("data:image/") and ";base64," in obj:
+        prefix = obj[: obj.index(";base64,") + len(";base64,")]
+        return prefix + obj[len(prefix) : len(prefix) + 20] + "..."
+    return obj
+
+
+async def main():
+    # -------------------------------------------------------------------------
+    # 1. Setup
+    # -------------------------------------------------------------------------
+    base_url = os.environ.get("SGLANG_BASE_URL", "http://localhost:30000")
+    client = SGLangClient(base_url=base_url)
+
+    model_info = await client.get_model_info()
+    model_path = os.environ.get("MODEL_PATH", model_info["model_path"])
+    processor = AutoProcessor.from_pretrained(model_path, trust_remote_code=True)
+
+    model = SGLangModel(
+        client=client,
+        processor=processor,
+        tool_parser=HermesToolParser(),
+        sampling_params={"max_new_tokens": 8192},
+    )
+
+    # -------------------------------------------------------------------------
+    # 2. Run VLM Agent
+    # -------------------------------------------------------------------------
+    print("\n" + "=" * 60)
+    print("VLM Agent Example")
+    print("=" * 60)
+
+    agent = Agent(
+        model=model,
+        tools=[read_image],
+        hooks=[ToolLimiter(max_tool_iters=5)],
+        system_prompt="",
+        callback_handler=None,
+    )
+
+    # Build prompt with inline image
+    image_a_bytes = (IMAGE_DIR / "a.jpg").read_bytes()
+    prompt = [
+        {"image": {"format": "jpeg", "source": {"bytes": image_a_bytes}}},
+        {"text": "This is a.jpg above. Now use read_image to load b.jpg. Then describe both images and compare them."},
+    ]
+
+    await agent.invoke_async(prompt)
+
+    print(f"\n[Trajectory]: {json.dumps(_summarize_for_display(agent.messages), indent=2)}")
+
+    # -------------------------------------------------------------------------
+    # 3. TITO Data (for RL training)
+    # -------------------------------------------------------------------------
+    print("\n" + "=" * 60)
+    print("TITO Token Manager State")
+    print("=" * 60)
+
+    tm = model.token_manager
+    print(f"  Total tokens:    {len(tm)}")
+    print(f"  Segments:        {len(tm.segment_info)}")
+    for i, (is_output, length) in enumerate(tm.segment_info):
+        seg_type = "RESPONSE" if is_output else "PROMPT"
+        print(f"    [{i}] {seg_type:10s} {length} tokens")
+
+    n_output = sum(tm.loss_mask)
+    print(f"\n  Initial prompt:  {tm.segment_info[0][1]} tokens")
+    print(f"  Rollout tokens:  {len(tm) - tm.segment_info[0][1]}")
+    print(f"  Output tokens:   {n_output}")
+    print(f"  Loss mask:       {tm.loss_mask[:10]}... (first 10)")
+
+    output_logprobs = [lp for lp, m in zip(tm.logprobs, tm.loss_mask) if m and lp is not None]
+    if output_logprobs:
+        print(f"  Avg logprob:     {sum(output_logprobs) / len(output_logprobs):.4f}")
+
+    # -------------------------------------------------------------------------
+    # 4. VLM State
+    # -------------------------------------------------------------------------
+    print("\n" + "=" * 60)
+    print("VLM State")
+    print("=" * 60)
+    print(f"  Images accumulated:  {len(model.image_data)}")
+    for i, img_url in enumerate(model.image_data):
+        print(f"    [{i}] {img_url[:50]}...")
+
+    # -------------------------------------------------------------------------
+    # 5. Multimodal Training Tensors (not managed by strands-sglang)
+    #
+    # For RL training, you typically need pixel_values and image_grid_thw
+    # alongside the token trajectory. These come from calling the HF processor
+    # on the accumulated images. This is outside strands-sglang's scope but
+    # shown here for completeness.
+    # -------------------------------------------------------------------------
+    print("\n" + "=" * 60)
+    print("Multimodal Training Tensors (from HF processor)")
+    print("=" * 60)
+
+    from io import BytesIO  # noqa: E402
+
+    from PIL import Image  # noqa: E402
+
+    pil_images = []
+    for data_url in model.image_data:
+        b64_data = data_url.split(";base64,", 1)[1]
+        pil_images.append(Image.open(BytesIO(base64.b64decode(b64_data))))
+
+    if pil_images:
+        # Re-format the conversation to get the chat template text (with image placeholders).
+        # We can't use decoded token text because it contains expanded <|image_pad|> tokens
+        # that would be double-counted by the processor.
+        chat_msgs = SGLangModel.format_messages(agent.messages, is_multimodal=True)
+        chat_text = processor.tokenizer.apply_chat_template(chat_msgs, tokenize=False, add_generation_prompt=False)
+        mm_inputs = processor(text=chat_text, images=pil_images, return_tensors="pt")
+
+        for key, val in mm_inputs.items():
+            if key == "input_ids":
+                continue  # already tracked by TokenManager
+            if hasattr(val, "shape"):
+                print(f"  {key}: shape={val.shape}, dtype={val.dtype}")
+            else:
+                print(f"  {key}: {type(val).__name__}")
+    else:
+        print("  No images — skipping")
+
+    # -------------------------------------------------------------------------
+    # 6. Full Context (decoded)
+    # -------------------------------------------------------------------------
+    print("\n" + "=" * 60)
+    print("Full Context (decoded token sequence)")
+    print("=" * 60)
+    print(model.tokenizer.decode(tm.token_ids, skip_special_tokens=False))
+
+    # Cleanup
+    model.reset()
+    await client.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ Repository = "https://github.com/horizon-rl/strands-sglang/"
 Issues = "https://github.com/horizon-rl/strands-sglang/issues"
 
 [project.optional-dependencies]
+vision = ["transformers[vision]"]  # also requires torch + torchvision, installed separately
 dev = [
     # Testing
     "pytest>=7.0.0",

--- a/src/strands_sglang/__init__.py
+++ b/src/strands_sglang/__init__.py
@@ -25,12 +25,13 @@ from .sglang import SGLangModel
 from .token import Token, TokenManager
 from .tool_limiter import MaxToolCallsReachedError, MaxToolIterationsReachedError, ToolLimiter
 from .tool_parsers import get_tool_parser
-from .utils import get_client, get_client_from_slime_args, get_tokenizer
+from .utils import get_client, get_client_from_slime_args, get_processor, get_tokenizer
 
 __all__ = [
     # Cache utilities
     "get_client",
     "get_client_from_slime_args",
+    "get_processor",
     "get_tokenizer",
     # Client
     "SGLangClient",

--- a/src/strands_sglang/sglang.py
+++ b/src/strands_sglang/sglang.py
@@ -59,7 +59,7 @@ from .token import TokenManager
 from .tool_parsers import HermesToolParser, ToolParser, ToolParseResult
 
 if TYPE_CHECKING:
-    from transformers import PreTrainedTokenizerBase
+    from transformers import PreTrainedTokenizerBase, ProcessorMixin
 
 logger = logging.getLogger(__name__)
 
@@ -92,7 +92,8 @@ class SGLangModel(Model):
         self,
         *,
         client: SGLangClient,
-        tokenizer: PreTrainedTokenizerBase,
+        tokenizer: PreTrainedTokenizerBase | None = None,
+        processor: ProcessorMixin | None = None,
         tool_parser: ToolParser | None = None,
         **config: Unpack[SGLangConfig],
     ) -> None:
@@ -100,12 +101,17 @@ class SGLangModel(Model):
 
         Args:
             client: `SGLangClient` for HTTP communication with the SGLang server.
-            tokenizer: HuggingFace tokenizer for chat template and tokenization.
+            tokenizer: HuggingFace tokenizer for chat template and tokenization (optional if processor is provided).
+            processor: HuggingFace processor for multimodal processing.
             tool_parser: `ToolParser` for tool calls (default: `HermesToolParser`).
             **config: Additional SGLang generation configuration.
         """
+
         self.client = client
-        self.tokenizer = tokenizer
+        self.processor = processor
+        self.tokenizer = (processor and processor.tokenizer) or tokenizer
+        if not self.tokenizer:
+            raise ValueError("Either tokenizer (text-only) or processor (multimodal) must be provided")
         self.tool_parser = tool_parser or HermesToolParser()
         self.config = dict(config)
 
@@ -113,6 +119,7 @@ class SGLangModel(Model):
         self.token_manager = TokenManager()
         self._processed_message_count: int = 0
         self.tool_parse_errors: dict[str, int] = {}  # per-tool parse error count
+        self.image_data: list[str] = []  # accumulated image data URLs (VLM only)
 
         logger.debug(f"initialized with config: {self.config}")
 
@@ -125,6 +132,12 @@ class SGLangModel(Model):
         self.token_manager.reset()
         self._processed_message_count = 0
         self.tool_parse_errors = {}
+        self.image_data = []
+
+    @property
+    def is_multimodal(self) -> bool:
+        """Whether the model is multimodal."""
+        return self.processor is not None
 
     # -------------------------------------------------------------------------
     # Model interface implementation
@@ -183,39 +196,31 @@ class SGLangModel(Model):
     ) -> list[dict[str, Any]]:
         """Convert Strands Messages to HF chat template format.
 
-        ``toolResult`` messages become ``role: "tool"`` messages.
-        Text-only content is flattened to a plain string.
-        ``toolUse`` blocks are skipped — tool calls live in the raw text
-        and are handled by :class:`ToolParser`.
+        When ``is_multimodal=False`` (default), content is flattened to a plain string.
+        When ``is_multimodal=True``, content is kept as a list of dicts.
         """
         result: list[dict[str, Any]] = []
 
         if system_prompt:
             result.append({"role": "system", "content": system_prompt})
 
+        # Each Strands message is {"role": str, "content": [ContentBlock, ...]}
+        # One Strands message maps to one HF message, except toolResult blocks
+        # which each become a separate HF message with role="tool".
         for msg in messages:
-            first_block = msg["content"][0]
-            tool_result = first_block.get("toolResult")
-            if tool_result:
-                for content_block in tool_result["content"]:
-                    result.append(
-                        {
-                            "role": "tool",
-                            "tool_call_id": tool_result["toolUseId"],
-                            "content": cls.format_content_block(content_block, is_multimodal),
-                        }
-                    )
+            if "toolResult" in msg["content"][0]:
+                # Each toolResult → its own HF message (different tool_call_id)
+                for cb in msg["content"]:
+                    assert "toolResult" in cb
+                    tr = cb["toolResult"]
+                    parts = [cls.format_content_block(c, is_multimodal) for c in tr["content"]]
+                    content = parts if is_multimodal else parts[0]
+                    result.append({"role": "tool", "tool_call_id": tr["toolUseId"], "content": content})
             else:
-                for content_block in msg["content"]:
-                    # toolUse blocks are skipped — tool calls live in the raw text
-                    if "toolUse" in content_block:
-                        continue
-                    result.append(
-                        {
-                            "role": msg["role"],
-                            "content": cls.format_content_block(content_block, is_multimodal),
-                        }
-                    )
+                # Non-tool content → one HF message (text, image, etc.; toolUse skipped)
+                content = [cls.format_content_block(cb, is_multimodal) for cb in msg["content"] if "toolUse" not in cb]
+                content = content if is_multimodal else content[0]
+                result.append({"role": msg["role"], "content": content})
 
         return result
 
@@ -247,7 +252,9 @@ class SGLangModel(Model):
         The result is manually tokenized (not model-generated) and added to
         the token trajectory with `loss_mask=False`.
         """
-        chat_messages = self.format_messages(messages, system_prompt)
+        chat_messages = self.format_messages(messages, system_prompt, is_multimodal=self.is_multimodal)
+        self.image_data.extend(self.extract_image_urls(chat_messages))
+        # TODO: add support for other modalities later
         return self.tokenizer.apply_chat_template(
             conversation=chat_messages,
             tools=tools,
@@ -255,6 +262,20 @@ class SGLangModel(Model):
             tokenize=False,
             enable_thinking=self.config.get("enable_thinking"),
         )
+
+    @staticmethod
+    def extract_image_urls(messages: list[dict[str, Any]]) -> list[str]:
+        """Extract image data URLs from HF-formatted multimodal messages."""
+        urls: list[str] = []
+        for msg in messages:
+            content = msg.get("content")
+            if isinstance(content, dict) and content.get("type") == "image":
+                urls.append(content["image"])
+            elif isinstance(content, list):
+                for part in content:
+                    if isinstance(part, dict) and part.get("type") == "image":
+                        urls.append(part["image"])
+        return urls
 
     # -------------------------------------------------------------------------
     # Generation
@@ -264,25 +285,33 @@ class SGLangModel(Model):
         self,
         messages: Messages,
         system_prompt: str | None,
-        tool_specs: list[dict] | None = None,
+        tools: list[dict] | None = None,
     ) -> list[int] | None:
         """Tokenize prompt messages for the next generation call.
 
         First call: tokenizes full prompt with system prompt and tools.
         Subsequent calls: tokenizes only new messages (tool results, user messages),
         prepending the message separator to align with chat template formatting.
+
+        For VLM (when ``self.processor`` is set), uses the processor to insert
+        image placeholder tokens based on ``self.image_data``.
         """
+
+        def _tokenize(text: str) -> list[int]:
+            if self.processor:
+                return self.processor(text=text, images=self.image_data or None)["input_ids"][0]
+            return self.tokenizer.encode(text, add_special_tokens=False)
+
         # First call: full prompt with tools
         if len(self.token_manager) == 0:
-            formatted = self.format_prompt(messages, system_prompt, tools=tool_specs)
-            return self.tokenizer.encode(formatted, add_special_tokens=False)
+            formatted = self.format_prompt(messages, system_prompt, tools=tools)
+            return _tokenize(formatted)
 
         # Subsequent calls: only new messages
         if len(messages) > self._processed_message_count:
             new_messages = self._sort_tool_results(messages[self._processed_message_count :])
             formatted = self.tool_parser.message_separator + self.format_prompt(new_messages)
-
-            return self.tokenizer.encode(formatted, add_special_tokens=False)
+            return _tokenize(formatted)
 
         return None
 
@@ -366,11 +395,11 @@ class SGLangModel(Model):
         This means users won't see streaming behavior such as print callbacks.
         """
         # Prepare request
-        formatted_tools = self.format_tool_specs(tool_specs) if tool_specs else None
+        tools = self.format_tool_specs(tool_specs) if tool_specs else None
         config = self.get_config()
         sampling_params: dict[str, Any] = dict(config.get("sampling_params") or {})
         return_logprob = config.get("return_logprob", True)
-        new_input_tokens = self.tokenize_prompt_messages(messages, system_prompt, tool_specs=formatted_tools)
+        new_input_tokens = self.tokenize_prompt_messages(messages, system_prompt, tools=tools)
         # Tracking token IDs in token_manager to ensure the token-in feature
         input_ids = self.token_manager.token_ids + (new_input_tokens or [])
 
@@ -385,6 +414,7 @@ class SGLangModel(Model):
                 sampling_params=sampling_params,
                 return_logprob=return_logprob,
                 logprob_start_len=0 if return_logprob else None,
+                image_data=self.image_data or None,
             )
 
             # Extract response data

--- a/src/strands_sglang/utils.py
+++ b/src/strands_sglang/utils.py
@@ -22,7 +22,7 @@ from typing import TYPE_CHECKING, Any
 from .client import DEFAULT_MAX_CONNECTIONS, SGLangClient
 
 if TYPE_CHECKING:
-    from transformers import PreTrainedTokenizer
+    from transformers import PreTrainedTokenizer, ProcessorMixin
 
 
 @lru_cache(maxsize=None)
@@ -83,3 +83,18 @@ def get_tokenizer(tokenizer_path: str) -> PreTrainedTokenizer:
     from transformers import AutoTokenizer
 
     return AutoTokenizer.from_pretrained(tokenizer_path, trust_remote_code=True)
+
+
+@lru_cache(maxsize=None)
+def get_processor(processor_path: str) -> ProcessorMixin:
+    """Get a shared (cached) multimodal processor.
+
+    Args:
+        processor_path: Path or HuggingFace model ID.
+
+    Returns:
+        Cached processor instance.
+    """
+    from transformers import AutoProcessor
+
+    return AutoProcessor.from_pretrained(processor_path, trust_remote_code=True)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -25,7 +25,7 @@ The model ID is auto-detected from the server's /get_model_info endpoint.
 
 import httpx
 import pytest
-from transformers import AutoTokenizer
+from transformers import AutoProcessor, AutoTokenizer, ProcessorMixin
 
 from strands_sglang import SGLangModel
 from strands_sglang.client import SGLangClient
@@ -93,6 +93,36 @@ async def model(tokenizer, sglang_base_url):
     yield SGLangModel(
         client=client,
         tokenizer=tokenizer,
+        tool_parser=HermesToolParser(),
+        sampling_params={"max_new_tokens": 32768},
+    )
+    await client.close()
+
+
+@pytest.fixture(scope="module")
+def processor(sglang_server_info):
+    """Load processor for VLM models; None for text-only models."""
+    model_path = sglang_server_info.get("tokenizer_path") or sglang_server_info["model_path"]
+    try:
+        proc = AutoProcessor.from_pretrained(model_path, trust_remote_code=True)
+    except (ImportError, ValueError):
+        # ImportError: missing torch/torchvision for VLM processors
+        # ValueError: processor config not found for text-only models
+        return None
+    if isinstance(proc, ProcessorMixin):
+        return proc
+    return None
+
+
+@pytest.fixture
+async def vlm_model(processor, sglang_base_url):
+    """Create fresh SGLangModel with processor for VLM tests."""
+    if processor is None:
+        pytest.skip("Server is running a text-only model")
+    client = SGLangClient(base_url=sglang_base_url)
+    yield SGLangModel(
+        client=client,
+        processor=processor,
         tool_parser=HermesToolParser(),
         sampling_params={"max_new_tokens": 32768},
     )

--- a/tests/integration/test_vlm_integration.py
+++ b/tests/integration/test_vlm_integration.py
@@ -1,0 +1,172 @@
+# Copyright 2025 Horizon RL Contributors
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Integration tests for VLM (Vision Language Model) support.
+
+Requires an SGLang server running a VLM model (e.g., Qwen3-VL-4B-Instruct).
+Tests are automatically skipped if the server is running a text-only model.
+"""
+
+import io
+
+import pytest
+from PIL import Image
+
+pytestmark = pytest.mark.integration
+
+
+def _make_test_png() -> bytes:
+    """Generate a valid 64x64 red PNG image in memory."""
+    img = Image.new("RGB", (64, 64), color=(255, 0, 0))
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+_TEST_PNG = _make_test_png()
+
+
+def _image_block() -> dict:
+    """Strands ImageContent block."""
+    return {"image": {"format": "png", "source": {"bytes": _TEST_PNG}}}
+
+
+class TestVLMGeneration:
+    """Basic VLM generation — model receives an image and produces text."""
+
+    async def test_simple_image_query(self, vlm_model):
+        """Model generates a response when given an image."""
+        messages = [{"role": "user", "content": [{"text": "What do you see in this image?"}, _image_block()]}]
+
+        events = []
+        async for event in vlm_model.stream(messages, system_prompt="Describe images briefly."):
+            events.append(event)
+
+        assert events[0] == {"messageStart": {"role": "assistant"}}
+        text_deltas = [e["contentBlockDelta"]["delta"]["text"] for e in events if "contentBlockDelta" in e]
+        assert len(text_deltas) > 0, "Model should produce text output"
+
+        stop_events = [e for e in events if "messageStop" in e]
+        assert stop_events[0]["messageStop"]["stopReason"] == "end_turn"
+
+    async def test_text_only_query_on_vlm(self, vlm_model):
+        """Text-only query still works on VLM model."""
+        messages = [{"role": "user", "content": [{"text": "What is 2+2?"}]}]
+
+        events = []
+        async for event in vlm_model.stream(messages):
+            events.append(event)
+
+        text_deltas = [e["contentBlockDelta"]["delta"]["text"] for e in events if "contentBlockDelta" in e]
+        assert len(text_deltas) > 0
+
+
+class TestVLMTITO:
+    """Token-in/Token-out tracking with VLM."""
+
+    async def test_prompt_and_response_segments(self, vlm_model):
+        """VLM generation produces correct prompt/response segments with proper loss mask."""
+        messages = [{"role": "user", "content": [{"text": "What color is this?"}, _image_block()]}]
+
+        async for _ in vlm_model.stream(messages):
+            pass
+
+        tm = vlm_model.token_manager
+        assert len(tm) > 0
+        assert len(tm.token_ids) == len(tm.loss_mask)
+
+        segments = tm.segment_info
+        assert len(segments) >= 2, f"Expected >= 2 segments, got {segments}"
+        # segment_info: (loss_mask, length) — False=prompt, True=response
+        assert segments[0][0] is False  # prompt
+        assert segments[1][0] is True  # response
+
+        prompt_len = segments[0][1]
+        response_len = segments[1][1]
+        assert all(m == 0 for m in tm.loss_mask[:prompt_len])
+        assert all(m == 1 for m in tm.loss_mask[prompt_len : prompt_len + response_len])
+
+    async def test_logprobs_for_response_tokens(self, vlm_model):
+        """Response tokens should have logprobs when return_logprob=True (default)."""
+        messages = [{"role": "user", "content": [{"text": "What is this?"}, _image_block()]}]
+
+        async for _ in vlm_model.stream(messages):
+            pass
+
+        tokens = vlm_model.token_manager.tokens
+        response_logprobs = [t.logprob for t in tokens if t.loss_mask]
+        # First output token may be None (SGLang quirk), rest should be present
+        assert any(lp is not None for lp in response_logprobs), "Should have logprobs for response tokens"
+
+
+class TestVLMImageData:
+    """Verify image_data accumulation and forwarding."""
+
+    async def test_image_data_accumulated(self, vlm_model):
+        """image_data should contain the image after generation."""
+        messages = [{"role": "user", "content": [{"text": "Describe."}, _image_block()]}]
+
+        async for _ in vlm_model.stream(messages):
+            pass
+
+        assert len(vlm_model.image_data) == 1
+        assert vlm_model.image_data[0].startswith("data:image/png;base64,")
+
+    async def test_multiple_images(self, vlm_model):
+        """Multiple images in one message are all accumulated."""
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"text": "Compare these images."},
+                    _image_block(),
+                    _image_block(),
+                ],
+            }
+        ]
+
+        async for _ in vlm_model.stream(messages):
+            pass
+
+        assert len(vlm_model.image_data) == 2
+
+
+class TestVLMMultiTurn:
+    """Multi-turn VLM conversations with image references."""
+
+    async def test_two_turn_with_image(self, vlm_model):
+        """Second turn can reference image from first turn."""
+        messages = [{"role": "user", "content": [{"text": "What is this image?"}, _image_block()]}]
+
+        # First turn
+        events1 = []
+        async for event in vlm_model.stream(messages):
+            events1.append(event)
+
+        first_response = "".join(
+            e["contentBlockDelta"]["delta"]["text"] for e in events1 if "contentBlockDelta" in e
+        )
+        tokens_after_first = len(vlm_model.token_manager)
+
+        # Second turn (no new image)
+        messages.append({"role": "assistant", "content": [{"text": first_response}]})
+        messages.append({"role": "user", "content": [{"text": "Can you be more specific?"}]})
+
+        async for _ in vlm_model.stream(messages):
+            pass
+
+        # Tokens should have grown
+        assert len(vlm_model.token_manager) > tokens_after_first
+        # Still only 1 image from the first turn
+        assert len(vlm_model.image_data) == 1

--- a/tests/unit/test_messages.py
+++ b/tests/unit/test_messages.py
@@ -124,7 +124,7 @@ class TestFormatMessagesRegression:
         assert new[0]["role"] == ref[0]["role"] == "tool"
         assert new[0]["content"] == ref[0]["content"]
 
-    def test_parallel_tool_results(self):
+    def test_parallel_tool_results_separate_messages(self):
         """Multiple tool results from parallel tool calls (each in separate message)."""
         messages = [
             {
@@ -156,6 +156,50 @@ class TestFormatMessagesRegression:
         ref = ref_format_messages(messages)
 
         assert len(new) == len(ref) == 2
+        for n, r in zip(new, ref):
+            assert n["role"] == r["role"] == "tool"
+            assert n["tool_call_id"] == r["tool_call_id"]
+            assert n["content"] == r["content"]
+
+    def test_parallel_tool_results_batched(self):
+        """Multiple tool results batched in one Strands message (real parallel tool call format).
+
+        Strands batches all parallel tool results into a single message:
+        {"role": "user", "content": [{"toolResult": ...}, {"toolResult": ...}, ...]}.
+        Each toolResult must produce its own HF message with role="tool".
+        """
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "toolResult": {
+                            "toolUseId": "call_0",
+                            "status": "success",
+                            "content": [{"text": "Result 0"}],
+                        }
+                    },
+                    {
+                        "toolResult": {
+                            "toolUseId": "call_1",
+                            "status": "success",
+                            "content": [{"text": "Result 1"}],
+                        }
+                    },
+                    {
+                        "toolResult": {
+                            "toolUseId": "call_2",
+                            "status": "success",
+                            "content": [{"text": "Result 2"}],
+                        }
+                    },
+                ],
+            },
+        ]
+        new = SGLangModel.format_messages(messages)
+        ref = ref_format_messages(messages)
+
+        assert len(new) == len(ref) == 3
         for n, r in zip(new, ref):
             assert n["role"] == r["role"] == "tool"
             assert n["tool_call_id"] == r["tool_call_id"]

--- a/tests/unit/test_sglang.py
+++ b/tests/unit/test_sglang.py
@@ -84,6 +84,58 @@ class TestFormatTools:
         assert result == []
 
 
+class TestFormatMessages:
+    """Tests for format_messages — especially parallel tool results."""
+
+    def test_parallel_tool_results_all_present(self):
+        """All toolResult blocks in one message must produce separate HF messages."""
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"toolResult": {"toolUseId": "call_0", "status": "success", "content": [{"text": "result 0"}]}},
+                    {"toolResult": {"toolUseId": "call_1", "status": "success", "content": [{"text": "result 1"}]}},
+                    {"toolResult": {"toolUseId": "call_2", "status": "success", "content": [{"text": "result 2"}]}},
+                ],
+            }
+        ]
+        result = SGLangModel.format_messages(messages)
+        tool_msgs = [m for m in result if m["role"] == "tool"]
+        assert len(tool_msgs) == 3
+        assert {m["tool_call_id"] for m in tool_msgs} == {"call_0", "call_1", "call_2"}
+
+    def test_single_tool_result(self):
+        """Single toolResult still works."""
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"toolResult": {"toolUseId": "call_0", "status": "success", "content": [{"text": "ok"}]}},
+                ],
+            }
+        ]
+        result = SGLangModel.format_messages(messages)
+        assert len(result) == 1
+        assert result[0]["role"] == "tool"
+        assert result[0]["content"] == "ok"
+
+    def test_tooluse_skipped(self):
+        """toolUse blocks are skipped — tool calls live in raw text."""
+        messages = [
+            {
+                "role": "assistant",
+                "content": [
+                    {"text": "<tool_call>...</tool_call>"},
+                    {"toolUse": {"toolUseId": "call_0", "name": "fn", "input": {}}},
+                ],
+            }
+        ]
+        result = SGLangModel.format_messages(messages)
+        assert len(result) == 1
+        assert result[0]["role"] == "assistant"
+        assert result[0]["content"] == "<tool_call>...</tool_call>"
+
+
 class TestFormatPrompt:
     """Tests for format_prompt method."""
 
@@ -125,7 +177,7 @@ class TestTokenizePromptMessages:
         messages = [{"role": "user", "content": [{"text": "Hello"}]}]
         tools = [{"type": "function", "function": {"name": "test"}}]
 
-        result = model.tokenize_prompt_messages(messages, system_prompt="Be helpful.", tool_specs=tools)
+        result = model.tokenize_prompt_messages(messages, system_prompt="Be helpful.", tools=tools)
 
         assert result == [1, 2, 3, 4, 5]
         mock_tokenizer.encode.assert_called_once()

--- a/tests/unit/test_vlm.py
+++ b/tests/unit/test_vlm.py
@@ -1,0 +1,392 @@
+# Copyright 2025 Horizon RL Contributors
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for VLM (Vision Language Model) support."""
+
+from __future__ import annotations
+
+import base64
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from strands_sglang import SGLangModel
+from strands_sglang.client import SGLangClient
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+# 1x1 red PNG (smallest valid PNG)
+_RED_PIXEL_PNG = (
+    b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01"
+    b"\x00\x00\x00\x01\x08\x02\x00\x00\x00\x90wS\xde\x00"
+    b"\x00\x00\x0cIDATx\x9cc\xf8\x0f\x00\x00\x01\x01\x00"
+    b"\x05\x18\xd8N\x00\x00\x00\x00IEND\xaeB`\x82"
+)
+_RED_PIXEL_B64 = base64.b64encode(_RED_PIXEL_PNG).decode()
+_RED_PIXEL_DATA_URL = f"data:image/png;base64,{_RED_PIXEL_B64}"
+
+
+def _image_block() -> dict:
+    """Strands ImageContent block."""
+    return {"image": {"format": "png", "source": {"bytes": _RED_PIXEL_PNG}}}
+
+
+@pytest.fixture
+def mock_processor():
+    """Mock HF processor with tokenizer sub-object."""
+    processor = MagicMock()
+    processor.tokenizer = MagicMock()
+    processor.tokenizer.encode.return_value = [1, 2, 3]
+    processor.tokenizer.apply_chat_template.return_value = "formatted prompt"
+    # processor(text=..., images=...) returns {"input_ids": [[...]]} (batch dim)
+    processor.return_value = {"input_ids": [[10, 20, 30]]}
+    return processor
+
+
+@pytest.fixture
+def mock_tokenizer():
+    """Mock tokenizer for text-only comparison."""
+    tokenizer = MagicMock()
+    tokenizer.encode.return_value = [1, 2, 3]
+    tokenizer.apply_chat_template.return_value = "formatted prompt"
+    return tokenizer
+
+
+@pytest.fixture
+def client():
+    return SGLangClient(base_url="http://localhost:30000")
+
+
+@pytest.fixture
+def vlm_model(client, mock_processor):
+    """SGLangModel with processor (VLM mode)."""
+    return SGLangModel(client=client, processor=mock_processor)
+
+
+@pytest.fixture
+def text_model(client, mock_tokenizer):
+    """SGLangModel with tokenizer only (text-only mode)."""
+    return SGLangModel(client=client, tokenizer=mock_tokenizer)
+
+
+# ---------------------------------------------------------------------------
+# Constructor and properties
+# ---------------------------------------------------------------------------
+
+
+class TestVLMConstructor:
+    def test_processor_stored(self, vlm_model, mock_processor):
+        assert vlm_model.processor is mock_processor
+
+    def test_tokenizer_from_processor(self, vlm_model, mock_processor):
+        assert vlm_model.tokenizer is mock_processor.tokenizer
+
+    def test_is_multimodal_true(self, vlm_model):
+        assert vlm_model.is_multimodal is True
+
+    def test_is_multimodal_false(self, text_model):
+        assert text_model.is_multimodal is False
+
+    def test_neither_tokenizer_nor_processor_raises(self, client):
+        with pytest.raises(ValueError, match="Either tokenizer"):
+            SGLangModel(client=client)
+
+    def test_tokenizer_only(self, client, mock_tokenizer):
+        model = SGLangModel(client=client, tokenizer=mock_tokenizer)
+        assert model.processor is None
+        assert model.tokenizer is mock_tokenizer
+
+    def test_both_tokenizer_and_processor_uses_processor_tokenizer(self, client, mock_processor, mock_tokenizer):
+        model = SGLangModel(client=client, tokenizer=mock_tokenizer, processor=mock_processor)
+        assert model.tokenizer is mock_processor.tokenizer
+
+
+# ---------------------------------------------------------------------------
+# format_content_block
+# ---------------------------------------------------------------------------
+
+
+class TestFormatContentBlockMultimodal:
+    """format_content_block with is_multimodal=True returns dicts, not strings."""
+
+    def test_text_block_returns_dict(self):
+        result = SGLangModel.format_content_block({"text": "hello"}, is_multimodal=True)
+        assert result == {"type": "text", "text": "hello"}
+
+    def test_text_block_returns_string_when_not_multimodal(self):
+        result = SGLangModel.format_content_block({"text": "hello"}, is_multimodal=False)
+        assert result == "hello"
+
+    def test_image_block_returns_data_url(self):
+        result = SGLangModel.format_content_block(_image_block(), is_multimodal=True)
+        assert result == {"type": "image", "image": _RED_PIXEL_DATA_URL}
+
+    def test_image_block_raises_when_not_multimodal(self):
+        """Image blocks require is_multimodal=True (no 'text' key to flatten to)."""
+        with pytest.raises(KeyError):
+            SGLangModel.format_content_block(_image_block(), is_multimodal=False)
+
+    def test_json_block_returns_dict(self):
+        result = SGLangModel.format_content_block({"json": {"key": "val"}}, is_multimodal=True)
+        assert result == {"type": "text", "text": '{"key": "val"}'}
+
+
+# ---------------------------------------------------------------------------
+# format_messages with is_multimodal
+# ---------------------------------------------------------------------------
+
+
+class TestFormatMessagesMultimodal:
+    def test_text_message_multimodal(self):
+        messages = [{"role": "user", "content": [{"text": "describe this"}]}]
+        result = SGLangModel.format_messages(messages, is_multimodal=True)
+        assert result == [{"role": "user", "content": [{"type": "text", "text": "describe this"}]}]
+
+    def test_image_message_multimodal(self):
+        messages = [{"role": "user", "content": [_image_block()]}]
+        result = SGLangModel.format_messages(messages, is_multimodal=True)
+        assert len(result) == 1
+        assert result[0]["content"][0]["type"] == "image"
+        assert result[0]["content"][0]["image"] == _RED_PIXEL_DATA_URL
+
+    def test_mixed_text_and_image(self):
+        """Text + image in same message are grouped into list content."""
+        messages = [{"role": "user", "content": [{"text": "what is this?"}, _image_block()]}]
+        result = SGLangModel.format_messages(messages, is_multimodal=True)
+        assert len(result) == 1
+        assert isinstance(result[0]["content"], list)
+        assert result[0]["content"][0] == {"type": "text", "text": "what is this?"}
+        assert result[0]["content"][1]["type"] == "image"
+
+    def test_tool_result_with_text_and_image(self):
+        """Tool result with text + image grouped into list content."""
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "toolResult": {
+                            "toolUseId": "call_001",
+                            "status": "success",
+                            "content": [{"text": "Image loaded"}, _image_block()],
+                        }
+                    }
+                ],
+            }
+        ]
+        result = SGLangModel.format_messages(messages, is_multimodal=True)
+        assert len(result) == 1
+        assert result[0]["role"] == "tool"
+        assert isinstance(result[0]["content"], list)
+        assert result[0]["content"][0] == {"type": "text", "text": "Image loaded"}
+        assert result[0]["content"][1]["type"] == "image"
+
+    def test_tool_result_single_block(self):
+        """Tool result with single block still gets list content in multimodal mode."""
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "toolResult": {
+                            "toolUseId": "call_001",
+                            "status": "success",
+                            "content": [_image_block()],
+                        }
+                    }
+                ],
+            }
+        ]
+        result = SGLangModel.format_messages(messages, is_multimodal=True)
+        assert result[0]["role"] == "tool"
+        assert result[0]["content"][0]["type"] == "image"
+
+
+# ---------------------------------------------------------------------------
+# extract_image_urls
+# ---------------------------------------------------------------------------
+
+
+class TestExtractImageUrls:
+    def test_extracts_from_image_messages(self):
+        messages = [
+            {"role": "user", "content": {"type": "image", "image": "data:image/png;base64,abc"}},
+            {"role": "user", "content": {"type": "text", "text": "describe this"}},
+            {"role": "user", "content": {"type": "image", "image": "data:image/jpeg;base64,xyz"}},
+        ]
+        result = SGLangModel.extract_image_urls(messages)
+        assert result == ["data:image/png;base64,abc", "data:image/jpeg;base64,xyz"]
+
+    def test_no_images(self):
+        messages = [{"role": "user", "content": "plain text"}]
+        assert SGLangModel.extract_image_urls(messages) == []
+
+    def test_skips_string_content(self):
+        """Text-only formatted messages have string content — should be skipped."""
+        messages = [
+            {"role": "user", "content": "hello"},
+            {"role": "user", "content": {"type": "image", "image": "data:image/png;base64,abc"}},
+        ]
+        assert SGLangModel.extract_image_urls(messages) == ["data:image/png;base64,abc"]
+
+    def test_extracts_from_list_content(self):
+        """Images in list content (grouped multimodal messages) are extracted."""
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "describe"},
+                    {"type": "image", "image": "data:image/png;base64,abc"},
+                ],
+            }
+        ]
+        assert SGLangModel.extract_image_urls(messages) == ["data:image/png;base64,abc"]
+
+
+# ---------------------------------------------------------------------------
+# tokenize_prompt_messages — VLM path
+# ---------------------------------------------------------------------------
+
+
+class TestTokenizePromptMessagesVLM:
+    def test_first_call_uses_processor(self, vlm_model, mock_processor):
+        messages = [{"role": "user", "content": [{"text": "Hello"}]}]
+        result = vlm_model.tokenize_prompt_messages(messages, system_prompt=None)
+
+        assert result == [10, 20, 30]
+        mock_processor.assert_called_once()
+        call_kwargs = mock_processor.call_args.kwargs
+        assert "text" in call_kwargs
+
+    def test_first_call_with_images_passes_image_data(self, vlm_model, mock_processor):
+        messages = [{"role": "user", "content": [{"text": "describe"}, _image_block()]}]
+        vlm_model.tokenize_prompt_messages(messages, system_prompt=None)
+
+        call_kwargs = mock_processor.call_args.kwargs
+        assert call_kwargs["images"] is not None
+        assert len(call_kwargs["images"]) == 1
+
+    def test_text_only_message_passes_images_none(self, vlm_model, mock_processor):
+        messages = [{"role": "user", "content": [{"text": "no images here"}]}]
+        vlm_model.tokenize_prompt_messages(messages, system_prompt=None)
+
+        call_kwargs = mock_processor.call_args.kwargs
+        assert call_kwargs["images"] is None
+
+    def test_text_model_uses_tokenizer_encode(self, text_model, mock_tokenizer):
+        messages = [{"role": "user", "content": [{"text": "Hello"}]}]
+        result = text_model.tokenize_prompt_messages(messages, system_prompt=None)
+
+        assert result == [1, 2, 3]
+        mock_tokenizer.encode.assert_called_once()
+
+    def test_subsequent_call_uses_processor(self, vlm_model, mock_processor):
+        """Incremental tokenization also goes through processor when VLM."""
+        vlm_model.token_manager.add_prompt([1, 2, 3])
+        vlm_model._processed_message_count = 1
+
+        messages = [
+            {"role": "user", "content": [{"text": "Hello"}]},
+            {"role": "assistant", "content": [{"text": "Hi"}]},
+            {"role": "user", "content": [{"text": "New message"}]},
+        ]
+        result = vlm_model.tokenize_prompt_messages(messages, system_prompt=None)
+
+        assert result == [10, 20, 30]
+        mock_processor.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Image accumulation across turns
+# ---------------------------------------------------------------------------
+
+
+class TestImageAccumulation:
+    def test_images_accumulated_across_calls(self, vlm_model, mock_processor):
+        """image_data grows across multiple format_prompt calls."""
+        # First turn: one image
+        messages1 = [{"role": "user", "content": [{"text": "describe"}, _image_block()]}]
+        vlm_model.tokenize_prompt_messages(messages1, system_prompt=None)
+        assert len(vlm_model.image_data) == 1
+
+        # Second turn: another image (simulate tool result with screenshot)
+        vlm_model.token_manager.add_prompt([10, 20, 30])
+        vlm_model._processed_message_count = 1
+        messages2 = [
+            {"role": "user", "content": [{"text": "describe"}, _image_block()]},
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "toolResult": {
+                            "toolUseId": "call_001",
+                            "status": "success",
+                            "content": [_image_block()],
+                        }
+                    }
+                ],
+            },
+        ]
+        vlm_model.tokenize_prompt_messages(messages2, system_prompt=None)
+        assert len(vlm_model.image_data) == 2  # 1 from first + 1 from second (tool result image)
+
+    def test_reset_clears_accumulated_images(self, vlm_model, mock_processor):
+        messages = [{"role": "user", "content": [{"text": "describe"}, _image_block()]}]
+        vlm_model.tokenize_prompt_messages(messages, system_prompt=None)
+        assert len(vlm_model.image_data) > 0
+
+        vlm_model.reset()
+        assert vlm_model.image_data == []
+
+
+# ---------------------------------------------------------------------------
+# stream() — image_data forwarding
+# ---------------------------------------------------------------------------
+
+
+class TestStreamImageData:
+    @pytest.mark.asyncio
+    async def test_image_data_passed_to_client(self, vlm_model, mock_processor):
+        """When image_data is non-empty, it's forwarded to client.generate."""
+        vlm_model.image_data = [_RED_PIXEL_DATA_URL]
+
+        with patch.object(vlm_model.client, "generate", new_callable=_async_mock_generate) as mock_gen:
+            async for _ in vlm_model.stream(
+                messages=[{"role": "user", "content": [{"text": "describe"}]}],
+            ):
+                pass
+            assert mock_gen.call_args.kwargs["image_data"] == [_RED_PIXEL_DATA_URL]
+
+    @pytest.mark.asyncio
+    async def test_no_image_data_passes_none(self, text_model, mock_tokenizer):
+        """When image_data is empty, image_data=None is passed."""
+        with patch.object(text_model.client, "generate", new_callable=_async_mock_generate) as mock_gen:
+            async for _ in text_model.stream(
+                messages=[{"role": "user", "content": [{"text": "hello"}]}],
+            ):
+                pass
+            assert mock_gen.call_args.kwargs["image_data"] is None
+
+
+def _async_mock_generate():
+    """Factory for async mock of client.generate that records call kwargs."""
+    mock = MagicMock()
+
+    async def _generate(**kwargs):
+        return {"text": "response", "output_ids": [100, 101], "meta_info": {}}
+
+    mock.side_effect = _generate
+    return mock


### PR DESCRIPTION
## Summary

- Add processor-based tokenization for vision-language models: when `processor` is provided, `SGLangModel` uses `processor(text, images)` instead of `tokenizer.encode(text)`
- Accumulate images as base64 data URLs and pass to SGLang via `image_data` parameter
- Rewrite `format_messages` to handle all content blocks correctly, fixing a bug that silently dropped parallel tool results (affected 2.6% of training samples — [evidence](docs/releases/parallel-tool-result-bug-evidence.txt))
- Add `get_processor` cached factory in `utils.py`
- Add VLM agent example with inline image + image-returning tool (adapted from #15)
- Multimodal training tensor extraction (`pixel_values`, `image_grid_thw`) is demonstrated at the example level only — it requires the full conversation context and is outside the scope of per-rollout TITO tracking

### VLM agent example output

```
TITO Token Manager State
  Total tokens:    930
  Segments:        4
    [0] PROMPT     359 tokens
    [1] RESPONSE   22 tokens
    [2] PROMPT     188 tokens
    [3] RESPONSE   361 tokens

VLM State
  Images accumulated:  2

Multimodal Training Tensors (from HF processor)
  attention_mask: shape=torch.Size([1, 909]), dtype=torch.int64
  pixel_values: shape=torch.Size([1856, 1536]), dtype=torch.float32
  image_grid_thw: shape=torch.Size([2, 3]), dtype=torch.int64
```

### Parallel tool result bug fix

The old `format_messages` used `first_block = msg["content"][0]` to detect `toolResult`, only processing the first block. When Strands batches multiple tool results in one message (from parallel tool calls), the remaining results were silently dropped during tokenization. Verified against real training data: 9 toolResults in messages but only 7 `<tool_response>` in the token trajectory.

## Acknowledgements

VLM agent example adapted from #15 by @weixiao-zhan. Thank you for the original VLM proposal that motivated this work.

## Test plan

- [x] 280 unit tests pass (including 38 new VLM + message formatting tests)
- [x] 72 integration tests pass against Qwen3-VL-4B-Instruct (65 text-only + 7 VLM)
- [x] VLM agent example runs successfully end-to-end
- [x] Regression tests for batched parallel tool results (compared against OpenAI reference implementation)
- [x] Linting clean (`ruff check` + `ruff format`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)