### PR TITLE
feat(utils): add DeepSeek-V3.2 tokenizer encoding support

### DIFF
--- a/src/strands_sglang/utils.py
+++ b/src/strands_sglang/utils.py
@@ -16,10 +16,15 @@
 
 from __future__ import annotations
 
+import importlib.util
+import logging
+import os
 from functools import lru_cache
 from typing import TYPE_CHECKING, Any
 
 from .client import DEFAULT_MAX_CONNECTIONS, SGLangClient
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from transformers import PreTrainedTokenizer, ProcessorMixin
@@ -74,6 +79,8 @@ def get_client_from_slime_args(
 def get_tokenizer(tokenizer_path: str) -> PreTrainedTokenizer:
     """Get a shared (cached) tokenizer.
 
+    For DeepSeek-V3.2, attach its encoding module to the tokenizer to construct `apply_chat_template()`.
+
     Args:
         tokenizer_path: Path or HuggingFace model ID for the tokenizer.
 
@@ -82,7 +89,80 @@ def get_tokenizer(tokenizer_path: str) -> PreTrainedTokenizer:
     """
     from transformers import AutoTokenizer
 
-    return AutoTokenizer.from_pretrained(tokenizer_path, trust_remote_code=True)
+    tokenizer = AutoTokenizer.from_pretrained(tokenizer_path, trust_remote_code=True)
+    # Auto-detect DeepSeek-V3.2 by checking for its encoding module
+    encoding_file = os.path.join(tokenizer.name_or_path, "encoding", "encoding_dsv32.py")
+    if os.path.isfile(encoding_file):
+        attach_dsv32_encoding(tokenizer)
+    return tokenizer
+
+
+def attach_dsv32_encoding(tokenizer: PreTrainedTokenizer) -> None:
+    """Attach DeepSeek-V3.2's encoding module to a tokenizer in-place.
+
+    Replaces `apply_chat_template()` with one that delegates to
+    DeepSeek-V3.2's `encoding/encoding_dsv32.py` module.
+
+    Call this when creating a tokenizer directly instead of using `get_tokenizer()`:
+
+        tokenizer = AutoTokenizer.from_pretrained("deepseek-ai/DeepSeek-V3.2")
+        attach_dsv32_encoding(tokenizer)
+
+    Args:
+        tokenizer: HuggingFace tokenizer to patch.
+    """
+    try:
+        cache_dir = tokenizer.name_or_path
+        filepath = os.path.join(cache_dir, "encoding", "encoding_dsv32.py")
+        spec = importlib.util.spec_from_file_location("encoding_dsv32", filepath)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        logger.info(f"Loaded DeepSeek V3.2's encoding module from {filepath}")
+    except Exception as e:
+        logger.error(f"Failed to load DeepSeek V3.2's encoding module from {filepath}: {e}")
+        raise
+
+    def apply_chat_template(
+        conversation: list[dict[str, Any]],
+        tools: list[dict] | None = None,
+        add_generation_prompt: bool = True,
+        enable_thinking: bool = True,
+        **kwargs: Any,
+    ) -> str:
+        """Format messages using DeepSeek-V3.2's `encode_messages()`.
+
+        Drop-in replacement for Jinja-based `apply_chat_template()`.
+        """
+
+        if kwargs:
+            logger.warning(f"DeepSeek V3.2 doesn't support the following kwargs: {kwargs}")
+
+        thinking_mode = "thinking" if enable_thinking else "chat"
+
+        # Incremental path: only tool results, no system/user context
+        if conversation and all(m.get("role") == "tool" for m in conversation):
+            result = "\n\n<function_results>"
+            for msg in conversation:
+                if msg.get("role") == "tool":
+                    result += "\n<result>" + msg.get("content", "") + "</result>"
+            result += "\n</function_results>"
+            if add_generation_prompt:
+                gen = "<think>" if thinking_mode == "thinking" else "</think>"
+                result += "\n\n" + gen
+            return result
+
+        # Attach tools to system message (encoding module reads them from msg.get("tools"))
+        messages = list(conversation)
+        if tools:
+            if messages and messages[0].get("role") == "system":
+                messages[0] = {**messages[0], "tools": tools}
+            else:
+                messages.insert(0, {"role": "system", "content": "", "tools": tools})
+
+        return module.encode_messages(messages, thinking_mode=thinking_mode)
+
+    # attach the new apply_chat_template to the tokenizer
+    tokenizer.apply_chat_template = apply_chat_template
 
 
 @lru_cache(maxsize=None)

--- a/tests/unit/dsv32_tokenizer/encoding/encoding_dsv32.py
+++ b/tests/unit/dsv32_tokenizer/encoding/encoding_dsv32.py
@@ -1,0 +1,398 @@
+import copy
+import json
+import re
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+TOOLS_SYSTEM_TEMPLATE = """## Tools
+
+You have access to a set of tools you can use to answer the user's question.
+You can invoke functions by writing a "<{dsml_token}function_calls>" block like the following as part of your reply to the user:
+<{dsml_token}function_calls>
+<{dsml_token}invoke name="$FUNCTION_NAME">
+<{dsml_token}parameter name="$PARAMETER_NAME" string="true|false">$PARAMETER_VALUE</{dsml_token}parameter>
+...
+</{dsml_token}invoke>
+<{dsml_token}invoke name="$FUNCTION_NAME2">
+...
+</{dsml_token}invoke>
+</{dsml_token}function_calls>
+
+String and scalar parameters should be specified as is without any escaping or quotes, while lists and objects should use JSON format. The "string" attribute should be set to "true" for string type parameters and "false" for other types (numbers, booleans, arrays, objects).
+
+If the thinking_mode is enabled, then after function results you should strongly consider outputting a thinking block. Here is an example:
+
+<{dsml_token}function_calls>
+...
+</{dsml_token}function_calls>
+
+<function_results>
+...
+</function_results>
+
+{thinking_start_token}...thinking about results{thinking_end_token}
+
+Here are the functions available in JSONSchema format:
+<functions>
+{tool_schemas}
+</functions>
+"""
+
+bos_token: str = "<｜begin▁of▁sentence｜>"
+eos_token: str = "<｜end▁of▁sentence｜>"
+thinking_start_token: str = "<think>"
+thinking_end_token: str = "</think>"
+dsml_token: str = "｜DSML｜"
+system_msg_template: str = "{content}"
+user_msg_template: str = "<｜User｜>{content}<｜Assistant｜>"
+assistant_msg_template: str = "{reasoning}{content}{tool_calls}<｜end▁of▁sentence｜>"
+thinking_template = "{reasoning_content}"
+
+response_format_template: str = (
+    "## Response Format:\n\nYou MUST strictly adhere to the following schema to reply:\n{schema}"
+)
+tool_call_template: str = '<{dsml_token}invoke name="{name}">\n{arguments}\n</{dsml_token}invoke>'
+tool_calls_template = "<{dsml_token}function_calls>\n{tool_calls}\n</{dsml_token}function_calls>"
+
+tool_output_template: str = "\n<result>{content}</result>"
+
+
+def to_json(value: Any) -> str:
+    try:
+        return json.dumps(value, ensure_ascii=False)
+    except Exception:
+        return json.dumps(value, ensure_ascii=True)
+
+
+def tools_from_openai_format(tools):
+    return [tool["function"] for tool in tools]
+
+
+def tool_calls_from_openai_format(tool_calls):
+    return [
+        {
+            "name": tool_call["function"]["name"],
+            "arguments": tool_call["function"]["arguments"],
+        }
+        for tool_call in tool_calls
+    ]
+
+
+def tool_calls_to_openai_format(tool_calls):
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": tool_call["name"],
+                "arguments": tool_call["arguments"],
+            },
+        }
+        for tool_call in tool_calls
+    ]
+
+
+def encode_arguments_to_dsml(tool_call: Dict[str, str]) -> str:
+    p_dsml_template = """<{dsml_token}parameter name="{key}" string="{is_str}">{value}</{dsml_token}parameter>"""
+    p_dsml_strs = []
+
+    arguments = json.loads(tool_call["arguments"])
+
+    for k, v in arguments.items():
+        p_dsml_str = p_dsml_template.format(
+            dsml_token=dsml_token,
+            key=k,
+            is_str="true" if isinstance(v, str) else "false",
+            value=v if isinstance(v, str) else to_json(v),
+        )
+
+        p_dsml_strs.append(p_dsml_str)
+
+    return "\n".join(p_dsml_strs)
+
+
+def decode_dsml_to_arguments(tool_name: str, tool_args: Dict[str, Tuple[str, str]]) -> Dict[str, str]:
+    def _decode_value(key: str, value: str, string: str):
+        if string == "true":
+            value = to_json(value)
+        return f"{to_json(key)}: {value}"
+
+    tool_args_json = "{" + ", ".join([_decode_value(k, v, string=is_str) for k, (v, is_str) in tool_args.items()]) + "}"
+    return dict(name=tool_name, arguments=tool_args_json)
+
+
+def render_tools(tools: List[Dict[str, Union[str, Dict[str, Any]]]]) -> str:
+    tools_json = [to_json(t) for t in tools]
+
+    return TOOLS_SYSTEM_TEMPLATE.format(
+        tool_schemas="\n".join(tools_json),
+        dsml_token=dsml_token,
+        thinking_start_token=thinking_start_token,
+        thinking_end_token=thinking_end_token,
+    )
+
+
+def find_last_user_index(messages: List[Dict[str, Any]]) -> int:
+    last_user_index = -1
+    for idx in range(len(messages) - 1, -1, -1):
+        if messages[idx].get("role") in ["user", "developer"]:
+            last_user_index = idx
+            break
+    return last_user_index
+
+
+def render_message(index: int, messages: List[Dict[str, Any]], thinking_mode: str) -> str:
+    assert 0 <= index < len(messages)
+    assert thinking_mode in ["chat", "thinking"], f"Invalid thinking_mode `{thinking_mode}`"
+
+    prompt = ""
+    msg = messages[index]
+    last_user_idx = find_last_user_index(messages)
+
+    role = msg.get("role")
+    content = msg.get("content")
+    tools = msg.get("tools")
+    response_format = msg.get("response_format")
+    tool_calls = msg.get("tool_calls")
+    reasoning_content = msg.get("reasoning_content")
+
+    if tools:
+        tools = tools_from_openai_format(tools)
+    if tool_calls:
+        tool_calls = tool_calls_from_openai_format(tool_calls)
+
+    if role == "system":
+        prompt += system_msg_template.format(content=content or "")
+        if tools:
+            prompt += "\n\n" + render_tools(tools)
+
+        if response_format:
+            prompt += "\n\n" + response_format_template.format(schema=to_json(response_format))
+
+    elif role == "developer":
+        assert content, f"Invalid message for role `{role}`: {msg}"
+        content_developer = ""
+        if tools:
+            content_developer += "\n\n" + render_tools(tools)
+
+        if response_format:
+            content_developer += "\n\n" + response_format_template.format(schema=to_json(response_format))
+
+        content_developer += "\n\n# The user's message is: {}".format(content)
+
+        prompt += user_msg_template.format(content=content_developer)
+        if index == last_user_idx and thinking_mode == "thinking":
+            prompt += thinking_start_token
+        else:
+            prompt += thinking_end_token
+
+    elif role == "user":
+        prompt += user_msg_template.format(content=content)
+
+        if index == last_user_idx and thinking_mode == "thinking":
+            prompt += thinking_start_token
+        else:
+            prompt += thinking_end_token
+
+    elif role == "tool":
+        prev_assistant_idx = index - 1
+        assistant_msg = messages[prev_assistant_idx]
+        while prev_assistant_idx >= 0 and assistant_msg.get("role") == "tool":
+            prev_assistant_idx -= 1
+            assistant_msg = messages[prev_assistant_idx]
+
+        assert index == 0 or prev_assistant_idx >= 0 and assistant_msg.get("role") == "assistant", (
+            f"Invalid messages at {index}:\n{assistant_msg}"
+        )
+
+        tool_call_order = index - prev_assistant_idx
+        assistant_tool_calls = assistant_msg.get("tool_calls")
+        assert assistant_tool_calls and len(assistant_tool_calls) >= tool_call_order, (
+            "No tool calls but found tool output"
+        )
+
+        if tool_call_order == 1:
+            prompt += "\n\n<function_results>"
+
+        prompt += tool_output_template.format(content=content)
+
+        if tool_call_order == len(assistant_tool_calls):
+            prompt += "\n</function_results>"
+
+            if index >= last_user_idx and thinking_mode == "thinking":
+                prompt += "\n\n" + thinking_start_token
+            else:
+                prompt += "\n\n" + thinking_end_token
+
+    elif role == "assistant":
+        prev_assistant_idx = index
+        thinking_part = ""
+
+        tool_calls_content = ""
+        if tool_calls:
+            tool_calls = [
+                tool_call_template.format(
+                    dsml_token=dsml_token, name=tool_call.get("name"), arguments=encode_arguments_to_dsml(tool_call)
+                )
+                for tool_call in tool_calls
+            ]
+            tool_calls_content += "\n\n" + tool_calls_template.format(
+                dsml_token=dsml_token, tool_calls="\n".join(tool_calls)
+            )
+
+        summary_content = content or ""
+
+        if thinking_mode == "thinking" and index > last_user_idx:
+            assert reasoning_content or tool_calls, (
+                f"ThinkingMode: {thinking_mode}, invalid message without reasoning_content/tool_calls `{msg}` after last user message"
+            )
+            thinking_part = thinking_template.format(reasoning_content=reasoning_content or "") + thinking_end_token
+
+        prompt += assistant_msg_template.format(
+            reasoning=thinking_part,
+            content=summary_content,
+            tool_calls=tool_calls_content,
+        )
+    else:
+        raise NotImplementedError(f"Unknown role: {role}")
+
+    return prompt
+
+
+def drop_thinking_messages(messages: List[Dict[str, Any]], last_user_idx: Optional[int] = None) -> List[Dict[str, Any]]:
+    messages_wo_thinking: List[Dict[str, Any]] = []
+    last_user_idx = find_last_user_index(messages) if last_user_idx is None else last_user_idx
+    for idx, msg in enumerate(messages):
+        role = msg.get("role")
+        if role in ["user", "system", "tool"] or idx >= last_user_idx:
+            messages_wo_thinking.append(msg)
+            continue
+
+        elif role == "assistant":
+            msg_wo_thinking = copy.copy(msg)
+            msg_wo_thinking.pop("reasoning_content", None)
+            messages_wo_thinking.append(msg_wo_thinking)
+
+    return messages_wo_thinking
+
+
+def encode_messages(
+    messages: List[Dict[str, Any]],
+    thinking_mode: str,
+    context: Optional[List[Dict[str, Any]]] = None,
+    drop_thinking: bool = True,
+    add_default_bos_token: bool = True,
+) -> str:
+    context = context if context else []
+    full_messages = context + messages
+
+    prompt = bos_token if add_default_bos_token and len(context) == 0 else ""
+
+    if thinking_mode == "thinking" and drop_thinking:
+        full_messages = drop_thinking_messages(full_messages)
+
+    for idx in range(len(messages)):
+        prompt += render_message(idx + len(context), full_messages, thinking_mode=thinking_mode)
+
+    return prompt
+
+
+def _read_until_stop(index: int, text: str, stop: List[str]) -> Tuple[int, str, Optional[str]]:
+    min_pos = len(text)
+    matched_stop = None
+
+    for s in stop:
+        pos = text.find(s, index)
+        if pos != -1 and pos < min_pos:
+            min_pos = pos
+            matched_stop = s
+
+    if matched_stop:
+        content = text[index:min_pos]
+        return min_pos + len(matched_stop), content, matched_stop
+    else:
+        content = text[index:]
+        return len(text), content, None
+
+
+def parse_tool_calls(index: int, text: str):
+    tool_calls: List[Dict[str, Any]] = []
+    stop_token = None
+    tool_calls_end_token = f"</{dsml_token}function_calls>"
+
+    while index < len(text):
+        index, _, stop_token = _read_until_stop(index, text, [f"<{dsml_token}invoke", tool_calls_end_token])
+        assert _ == ">\n", "Tool call format error"
+
+        if stop_token == tool_calls_end_token:
+            break
+
+        assert stop_token is not None, "Missing special token"
+
+        index, tool_name_content, stop_token = _read_until_stop(
+            index, text, [f"<{dsml_token}parameter", f"</{dsml_token}invoke"]
+        )
+
+        p_tool_name = re.findall(r'^\s*name="(.*?)">\n$', tool_name_content, flags=re.DOTALL)
+        assert len(p_tool_name) == 1, "Tool name format error"
+        tool_name = p_tool_name[0]
+
+        tool_args: Dict[str, Tuple[str, str]] = {}
+        while stop_token == f"<{dsml_token}parameter":
+            index, param_content, stop_token = _read_until_stop(index, text, [f"/{dsml_token}parameter"])
+
+            param_kv = re.findall(r'^ name="(.*?)" string="(true|false)">(.*?)<$', param_content, flags=re.DOTALL)
+            assert len(param_kv) == 1, "Parameter format error"
+            param_name, string, param_value = param_kv[0]
+
+            assert param_name not in tool_args, "Duplicate parameter name"
+            tool_args[param_name] = (param_value, string)
+
+            index, content, stop_token = _read_until_stop(
+                index, text, [f"<{dsml_token}parameter", f"</{dsml_token}invoke"]
+            )
+            assert content == ">\n", "Parameter format error"
+
+        tool_call = decode_dsml_to_arguments(tool_name=tool_name, tool_args=tool_args)
+        tool_calls.append(tool_call)
+
+    return index, stop_token, tool_calls
+
+
+# NOTE: This function is designed to parse only correctly formatted string and will not attempt to correct malformed output that may be generated by the model.
+def parse_message_from_completion_text(text: str, thinking_mode: str):
+    summary_content, reasoning_content, tool_calls = "", "", []
+    index, stop_token = 0, None
+    tool_calls_start_token = f"\n\n<{dsml_token}function_calls"
+
+    is_thinking, is_tool_calling = thinking_mode == "thinking", False
+
+    if is_thinking:
+        index, content_delta, stop_token = _read_until_stop(index, text, [thinking_end_token, tool_calls_start_token])
+        reasoning_content = content_delta
+        assert stop_token == thinking_end_token, "Invalid thinking format"
+
+    index, content_delta, stop_token = _read_until_stop(index, text, [eos_token, tool_calls_start_token])
+    summary_content = content_delta
+    if stop_token == tool_calls_start_token:
+        is_tool_calling = True
+    else:
+        assert stop_token == eos_token, "Invalid summary format"
+
+    if is_tool_calling:
+        index, stop_token, tool_calls = parse_tool_calls(index, text)
+
+        index, tool_ends_text, stop_token = _read_until_stop(index, text, [eos_token])
+        assert not tool_ends_text, "Unexpected content after tool calls"
+
+    assert len(text) == index and stop_token in [eos_token, None], "Unexpected content at end"
+
+    for sp_token in [bos_token, eos_token, thinking_start_token, thinking_end_token, dsml_token]:
+        assert sp_token not in summary_content and sp_token not in reasoning_content, (
+            "Unexpected special token in content"
+        )
+
+    return {
+        "role": "assistant",
+        "content": summary_content,
+        "reasoning_content": reasoning_content,
+        "tool_calls": tool_calls_to_openai_format(tool_calls),
+    }

--- a/tests/unit/dsv32_tokenizer/test_dsv32_tokenizer.py
+++ b/tests/unit/dsv32_tokenizer/test_dsv32_tokenizer.py
@@ -1,0 +1,330 @@
+# Copyright 2025 Horizon RL Contributors
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for DeepSeek-V3.2 encoding attachment and apply_chat_template.
+
+Uses DeepSeek's own encoding module and golden test cases from:
+https://huggingface.co/deepseek-ai/DeepSeek-V3.2/tree/main/encoding
+"""
+
+import importlib.util
+import json
+import logging
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from strands_sglang.utils import attach_dsv32_encoding
+
+FIXTURES_DIR = Path(__file__).parent
+
+
+@pytest.fixture
+def encoding_module():
+    """Load the real encoding_dsv32 module from fixtures."""
+    spec = importlib.util.spec_from_file_location("encoding_dsv32", FIXTURES_DIR / "encoding" / "encoding_dsv32.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def tokenizer():
+    """Mock tokenizer with name_or_path pointing to the fixtures directory.
+
+    attach_dsv32_encoding looks for {name_or_path}/encoding/encoding_dsv32.py,
+    so we point to the parent of the encoding/ directory.
+    """
+    tok = MagicMock()
+    tok.name_or_path = str(FIXTURES_DIR)
+    return tok
+
+
+@pytest.fixture
+def patched_tokenizer(tokenizer):
+    """Tokenizer with apply_chat_template replaced by the real encoding module."""
+    attach_dsv32_encoding(tokenizer)
+    return tokenizer
+
+
+@pytest.fixture
+def test_data():
+    """Load DeepSeek's golden test input."""
+    with open(FIXTURES_DIR / "test_input.json") as f:
+        return json.load(f)
+
+
+@pytest.fixture
+def golden_output():
+    """Load DeepSeek's golden expected output."""
+    with open(FIXTURES_DIR / "test_output.txt") as f:
+        return f.read().strip()
+
+
+class TestFullConversation:
+    """Tests using real encoding module and DeepSeek's golden test cases."""
+
+    def test_matches_golden_output(self, patched_tokenizer, test_data, golden_output):
+        """Full conversation with tools matches DeepSeek's golden output."""
+        result = patched_tokenizer.apply_chat_template(
+            conversation=test_data["messages"],
+            tools=test_data["tools"],
+            enable_thinking=True,
+        )
+        assert result == golden_output
+
+    def test_wrapper_matches_direct_encode_messages(self, patched_tokenizer, encoding_module, test_data):
+        """Wrapper output identical to calling encode_messages() directly."""
+        # Direct call (how DeepSeek's own test does it)
+        messages = [msg.copy() for msg in test_data["messages"]]
+        messages[0]["tools"] = test_data["tools"]
+        direct = encoding_module.encode_messages(messages, thinking_mode="thinking")
+
+        # Via our wrapper
+        wrapped = patched_tokenizer.apply_chat_template(
+            conversation=test_data["messages"],
+            tools=test_data["tools"],
+            enable_thinking=True,
+        )
+
+        assert wrapped == direct
+
+    def test_tools_attached_to_existing_system_message(self, patched_tokenizer, encoding_module, test_data):
+        """Tools merged into existing system message produce correct output."""
+        # Build expected: system message with tools attached
+        messages = [msg.copy() for msg in test_data["messages"]]
+        messages[0]["tools"] = test_data["tools"]
+        expected = encoding_module.encode_messages(messages, thinking_mode="thinking")
+
+        # Our wrapper handles tool attachment
+        result = patched_tokenizer.apply_chat_template(
+            conversation=test_data["messages"],
+            tools=test_data["tools"],
+            enable_thinking=True,
+        )
+
+        assert result == expected
+
+    def test_synthetic_system_message_when_none_exists(self, patched_tokenizer, encoding_module, test_data):
+        """Synthetic system message created when tools given but no system message."""
+        # Remove system message from conversation
+        messages_no_system = [m for m in test_data["messages"] if m.get("role") != "system"]
+
+        # Our wrapper should insert a synthetic system message with tools
+        result = patched_tokenizer.apply_chat_template(
+            conversation=messages_no_system,
+            tools=test_data["tools"],
+            enable_thinking=True,
+        )
+
+        # Direct: manually add synthetic system message
+        synthetic = [{"role": "system", "content": "", "tools": test_data["tools"]}] + messages_no_system
+        expected = encoding_module.encode_messages(synthetic, thinking_mode="thinking")
+
+        assert result == expected
+
+    def test_chat_mode(self, patched_tokenizer, encoding_module, test_data):
+        """enable_thinking=False passes thinking_mode='chat'."""
+        messages = [msg.copy() for msg in test_data["messages"]]
+        messages[0]["tools"] = test_data["tools"]
+        expected = encoding_module.encode_messages(messages, thinking_mode="chat")
+
+        result = patched_tokenizer.apply_chat_template(
+            conversation=test_data["messages"],
+            tools=test_data["tools"],
+            enable_thinking=False,
+        )
+
+        assert result == expected
+
+    def test_input_messages_not_mutated(self, patched_tokenizer, test_data):
+        """Original messages list and dicts are not modified."""
+        messages = test_data["messages"]
+        original_len = len(messages)
+        original_system = dict(messages[0])
+
+        patched_tokenizer.apply_chat_template(
+            conversation=messages,
+            tools=test_data["tools"],
+            enable_thinking=True,
+        )
+
+        assert len(messages) == original_len
+        assert messages[0] == original_system
+        assert "tools" not in messages[0]
+
+
+class TestIncrementalPath:
+    """Tests for incremental (tool-result-only) formatting.
+
+    The incremental path produces the same format as encode_messages()
+    renders tool messages, verified against the module's template strings.
+    """
+
+    def test_single_tool_result(self, patched_tokenizer):
+        """Single tool result matches expected format."""
+        messages = [{"role": "tool", "content": "result data"}]
+        result = patched_tokenizer.apply_chat_template(messages, enable_thinking=True)
+
+        assert result == "\n\n<function_results>\n<result>result data</result>\n</function_results>\n\n<think>"
+
+    def test_multiple_tool_results(self, patched_tokenizer):
+        """Multiple tool results each get their own <result> tag."""
+        messages = [
+            {"role": "tool", "content": "result1"},
+            {"role": "tool", "content": "result2"},
+        ]
+        result = patched_tokenizer.apply_chat_template(messages, enable_thinking=True)
+
+        expected = (
+            "\n\n<function_results>"
+            "\n<result>result1</result>"
+            "\n<result>result2</result>"
+            "\n</function_results>"
+            "\n\n<think>"
+        )
+        assert result == expected
+
+    def test_format_matches_module_templates(self, patched_tokenizer, encoding_module):
+        """Incremental format uses the same template strings as the encoding module."""
+        content = "test content"
+        result = patched_tokenizer.apply_chat_template(
+            [{"role": "tool", "content": content}],
+            enable_thinking=True,
+        )
+
+        # Verify against the module's tool_output_template
+        expected_result_tag = encoding_module.tool_output_template.format(content=content)
+        assert expected_result_tag in result
+
+    def test_thinking_mode_appends_think_start(self, patched_tokenizer):
+        """Thinking mode appends <think> for generation prompt."""
+        result = patched_tokenizer.apply_chat_template(
+            [{"role": "tool", "content": "ok"}],
+            enable_thinking=True,
+        )
+        assert result.endswith("<think>")
+
+    def test_chat_mode_appends_think_end(self, patched_tokenizer):
+        """Chat mode appends </think> — matches DeepSeek's encoding module behavior."""
+        result = patched_tokenizer.apply_chat_template(
+            [{"role": "tool", "content": "ok"}],
+            enable_thinking=False,
+        )
+        assert result.endswith("</think>")
+
+    def test_no_generation_prompt(self, patched_tokenizer):
+        """No thinking tag without add_generation_prompt."""
+        result = patched_tokenizer.apply_chat_template(
+            [{"role": "tool", "content": "ok"}],
+            add_generation_prompt=False,
+        )
+        assert result.endswith("</function_results>")
+        assert "<think>" not in result
+        assert "</think>" not in result
+
+    def test_empty_content_defaults_to_empty_string(self, patched_tokenizer):
+        """Tool result with missing content uses empty string."""
+        result = patched_tokenizer.apply_chat_template([{"role": "tool"}], enable_thinking=True)
+        assert "<result></result>" in result
+
+    def test_mixed_roles_uses_full_path(self, patched_tokenizer, encoding_module):
+        """Messages with mixed roles go through encode_messages(), not incremental."""
+        messages = [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "hi"},
+        ]
+
+        result = patched_tokenizer.apply_chat_template(messages, enable_thinking=True)
+        expected = encoding_module.encode_messages(messages, thinking_mode="thinking")
+
+        assert result == expected
+
+
+class TestAttachDsv32Encoding:
+    """Tests for attach_dsv32_encoding() glue logic."""
+
+    def test_replaces_apply_chat_template(self, patched_tokenizer):
+        """apply_chat_template is replaced with a callable."""
+        assert callable(patched_tokenizer.apply_chat_template)
+
+    def test_module_load_failure_raises(self):
+        """Raises when the encoding module cannot be loaded."""
+        tok = MagicMock()
+        tok.name_or_path = "/nonexistent/path"
+
+        with pytest.raises(Exception):
+            attach_dsv32_encoding(tok)
+
+    def test_kwargs_warning(self, patched_tokenizer, caplog):
+        """Unknown kwargs emit a warning."""
+        with caplog.at_level(logging.WARNING, logger="strands_sglang.utils"):
+            patched_tokenizer.apply_chat_template(
+                conversation=[{"role": "user", "content": "hi"}],
+                tokenize=False,
+            )
+
+        assert "tokenize" in caplog.text
+
+    def test_kwargs_no_warning_when_empty(self, patched_tokenizer, caplog):
+        """No warning when no extra kwargs passed."""
+        with caplog.at_level(logging.WARNING, logger="strands_sglang.utils"):
+            patched_tokenizer.apply_chat_template(
+                conversation=[{"role": "tool", "content": "ok"}],
+            )
+
+        assert "doesn't support" not in caplog.text
+
+
+class TestGetTokenizerAutoDetect:
+    """Tests for get_tokenizer() auto-detection of DeepSeek-V3.2."""
+
+    def setup_method(self):
+        from strands_sglang.utils import get_tokenizer
+
+        get_tokenizer.cache_clear()
+
+    @patch("strands_sglang.utils.attach_dsv32_encoding")
+    @patch("strands_sglang.utils.os.path.isfile", return_value=True)
+    @patch("transformers.AutoTokenizer")
+    def test_detects_dsv32_and_attaches(self, mock_auto, _mock_isfile, mock_attach):
+        """get_tokenizer calls attach_dsv32_encoding when encoding file exists."""
+        mock_tokenizer = MagicMock()
+        mock_tokenizer.name_or_path = "/models/deepseek-v32"
+        mock_auto.from_pretrained.return_value = mock_tokenizer
+
+        from strands_sglang.utils import get_tokenizer
+
+        result = get_tokenizer("/models/deepseek-v32")
+
+        mock_attach.assert_called_once_with(mock_tokenizer)
+        assert result is mock_tokenizer
+
+    @patch("strands_sglang.utils.attach_dsv32_encoding")
+    @patch("strands_sglang.utils.os.path.isfile", return_value=False)
+    @patch("transformers.AutoTokenizer")
+    def test_skips_non_dsv32(self, mock_auto, _mock_isfile, mock_attach):
+        """get_tokenizer skips attachment when encoding file doesn't exist."""
+        mock_tokenizer = MagicMock()
+        mock_tokenizer.name_or_path = "/models/qwen3"
+        mock_auto.from_pretrained.return_value = mock_tokenizer
+
+        from strands_sglang.utils import get_tokenizer
+
+        get_tokenizer.cache_clear()
+        result = get_tokenizer("/models/qwen3")
+
+        mock_attach.assert_not_called()
+        assert result is mock_tokenizer

--- a/tests/unit/dsv32_tokenizer/test_input.json
+++ b/tests/unit/dsv32_tokenizer/test_input.json
@@ -1,0 +1,149 @@
+{
+    "tools": [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_datetime",
+                "description": "Get the current date and time",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "timezone": {
+                            "type": "string",
+                            "description": "The timezone, e.g. Asia/Shanghai, UTC"
+                        }
+                    },
+                    "required": ["timezone"]
+                }
+            }
+        },
+        {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "description": "Get the weather for a specific date and location",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "location": {
+                            "type": "string",
+                            "description": "The city name, e.g. Beijing, Hangzhou"
+                        },
+                        "date": {
+                            "type": "string",
+                            "description": "The date in YYYY-MM-DD format"
+                        }
+                    },
+                    "required": ["location", "date"]
+                }
+            }
+        }
+    ],
+    "messages": [
+        {
+            "role": "system",
+            "content": "You are a helpful Assistant."
+        },
+        {
+            "role": "user",
+            "content": "明天杭州和北京的天气怎么样？"
+        },
+        {
+            "role": "assistant",
+            "reasoning_content": "用户询问明天的天气，我需要先获取当前日期来计算明天的日期📅",
+            "tool_calls": [
+                {
+                    "id": "call_xK9mN3pL2qR8vT5wY6hZ1aB4",
+                    "type": "function",
+                    "function": {
+                        "arguments": "{\"timezone\": \"Asia/Shanghai\"}",
+                        "name": "get_datetime"
+                    }
+                }
+            ]
+        },
+        {
+            "tool_call_id": "call_xK9mN3pL2qR8vT5wY6hZ1aB4",
+            "role": "tool",
+            "content": "{\"current_date\": \"2024-01-15\", \"current_time\": \"14:30:00\", \"timezone\": \"Asia/Shanghai\"}"
+        },
+        {
+            "role": "assistant",
+            "reasoning_content": "现在知道今天是2024-01-15，明天就是2024-01-16。接下来查询杭州和北京明天的天气🌤️",
+            "tool_calls": [
+                {
+                    "id": "call_bN7kR9mX3pQ2wL5vY8jZ4cD6",
+                    "type": "function",
+                    "function": {
+                        "arguments": "{\"location\": \"Hangzhou\", \"date\": \"2024-01-16\"}",
+                        "name": "get_weather"
+                    }
+                },
+                {
+                    "id": "call_dP9mL7kX5rT4yN3wZ2hV8eF1",
+                    "type": "function",
+                    "function": {
+                        "arguments": "{\"location\": \"Beijing\", \"date\": \"2024-01-16\"}",
+                        "name": "get_weather"
+                    }
+                }
+            ]
+        },
+        {
+            "tool_call_id": "call_bN7kR9mX3pQ2wL5vY8jZ4cD6",
+            "role": "tool",
+            "content": "{\"location\": \"Hangzhou\", \"date\": \"2024-01-16\", \"temperature_high\": \"12\", \"temperature_low\": \"5\", \"weather\": \"多云\", \"humidity\": \"65%\"}"
+        },
+        {
+            "tool_call_id": "call_dP9mL7kX5rT4yN3wZ2hV8eF1",
+            "role": "tool",
+            "content": "{\"location\": \"Beijing\", \"date\": \"2024-01-16\", \"temperature_high\": \"-2\", \"temperature_low\": \"-8\", \"weather\": \"晴\", \"humidity\": \"30%\"}"
+        },
+        {
+            "role": "assistant",
+            "reasoning_content": "已获取两个城市明天的天气信息，现在整理给用户✨",
+            "content": "根据查询结果，明天（2024年1月16日）的天气情况如下：\n\n**杭州**：\n- 天气：多云\n- 最高温度：12°C\n- 最低温度：5°C\n- 湿度：65%\n\n**北京**：\n- 天气：晴\n- 最高温度：-2°C\n- 最低温度：-8°C\n- 湿度：30%\n\n杭州明天会比较温暖但有些多云，而北京会很冷但是晴天。建议在北京的朋友要注意保暖！"
+        },
+        {
+            "role": "user",
+            "content": "谢谢！那后天呢？"
+        },
+        {
+            "role": "assistant",
+            "reasoning_content": "用户现在问后天的天气，后天是2024-01-17，我可以直接查询（因为已知今天日期）🗓️",
+            "tool_calls": [
+                {
+                    "id": "call_fR3nK8mV7pL4xT2yW9jB5gH3",
+                    "type": "function",
+                    "function": {
+                        "arguments": "{\"location\": \"Hangzhou\", \"date\": \"2024-01-17\"}",
+                        "name": "get_weather"
+                    }
+                },
+                {
+                    "id": "call_hT5pN2kY9rV6zL3wX1mD7jK8",
+                    "type": "function",
+                    "function": {
+                        "arguments": "{\"location\": \"Beijing\", \"date\": \"2024-01-17\"}",
+                        "name": "get_weather"
+                    }
+                }
+            ]
+        },
+        {
+            "tool_call_id": "call_fR3nK8mV7pL4xT2yW9jB5gH3",
+            "role": "tool",
+            "content": "{\"location\": \"Hangzhou\", \"date\": \"2024-01-17\", \"temperature_high\": \"15\", \"temperature_low\": \"8\", \"weather\": \"小雨\", \"humidity\": \"80%\"}"
+        },
+        {
+            "tool_call_id": "call_hT5pN2kY9rV6zL3wX1mD7jK8",
+            "role": "tool",
+            "content": "{\"location\": \"Beijing\", \"date\": \"2024-01-17\", \"temperature_high\": \"0\", \"temperature_low\": \"-6\", \"weather\": \"多云\", \"humidity\": \"45%\"}"
+        },
+        {
+            "role": "assistant",
+            "reasoning_content": "获取到后天的天气数据，整理回复给用户📝",
+            "content": "后天（2024年1月17日）的天气情况：\n\n**杭州**：\n- 天气：小雨\n- 最高温度：15°C\n- 最低温度：8°C\n- 湿度：80%\n\n**北京**：\n- 天气：多云\n- 最高温度：0°C\n- 最低温度：-6°C\n- 湿度：45%\n\n杭州后天会有小雨，温度略有回升，记得带伞。北京会稍微暖和一点，但依然很冷，请继续做好保暖措施。"
+        }
+    ]
+}

--- a/tests/unit/dsv32_tokenizer/test_output.txt
+++ b/tests/unit/dsv32_tokenizer/test_output.txt
@@ -1,0 +1,112 @@
+<｜begin▁of▁sentence｜>You are a helpful Assistant.
+
+## Tools
+
+You have access to a set of tools you can use to answer the user's question.
+You can invoke functions by writing a "<｜DSML｜function_calls>" block like the following as part of your reply to the user:
+<｜DSML｜function_calls>
+<｜DSML｜invoke name="$FUNCTION_NAME">
+<｜DSML｜parameter name="$PARAMETER_NAME" string="true|false">$PARAMETER_VALUE</｜DSML｜parameter>
+...
+</｜DSML｜invoke>
+<｜DSML｜invoke name="$FUNCTION_NAME2">
+...
+</｜DSML｜invoke>
+</｜DSML｜function_calls>
+
+String and scalar parameters should be specified as is without any escaping or quotes, while lists and objects should use JSON format. The "string" attribute should be set to "true" for string type parameters and "false" for other types (numbers, booleans, arrays, objects).
+
+If the thinking_mode is enabled, then after function results you should strongly consider outputting a thinking block. Here is an example:
+
+<｜DSML｜function_calls>
+...
+</｜DSML｜function_calls>
+
+<function_results>
+...
+</function_results>
+
+<think>...thinking about results</think>
+
+Here are the functions available in JSONSchema format:
+<functions>
+{"name": "get_datetime", "description": "Get the current date and time", "parameters": {"type": "object", "properties": {"timezone": {"type": "string", "description": "The timezone, e.g. Asia/Shanghai, UTC"}}, "required": ["timezone"]}}
+{"name": "get_weather", "description": "Get the weather for a specific date and location", "parameters": {"type": "object", "properties": {"location": {"type": "string", "description": "The city name, e.g. Beijing, Hangzhou"}, "date": {"type": "string", "description": "The date in YYYY-MM-DD format"}}, "required": ["location", "date"]}}
+</functions>
+<｜User｜>明天杭州和北京的天气怎么样？<｜Assistant｜></think>
+
+<｜DSML｜function_calls>
+<｜DSML｜invoke name="get_datetime">
+<｜DSML｜parameter name="timezone" string="true">Asia/Shanghai</｜DSML｜parameter>
+</｜DSML｜invoke>
+</｜DSML｜function_calls><｜end▁of▁sentence｜>
+
+<function_results>
+<result>{"current_date": "2024-01-15", "current_time": "14:30:00", "timezone": "Asia/Shanghai"}</result>
+</function_results>
+
+</think>
+
+<｜DSML｜function_calls>
+<｜DSML｜invoke name="get_weather">
+<｜DSML｜parameter name="location" string="true">Hangzhou</｜DSML｜parameter>
+<｜DSML｜parameter name="date" string="true">2024-01-16</｜DSML｜parameter>
+</｜DSML｜invoke>
+<｜DSML｜invoke name="get_weather">
+<｜DSML｜parameter name="location" string="true">Beijing</｜DSML｜parameter>
+<｜DSML｜parameter name="date" string="true">2024-01-16</｜DSML｜parameter>
+</｜DSML｜invoke>
+</｜DSML｜function_calls><｜end▁of▁sentence｜>
+
+<function_results>
+<result>{"location": "Hangzhou", "date": "2024-01-16", "temperature_high": "12", "temperature_low": "5", "weather": "多云", "humidity": "65%"}</result>
+<result>{"location": "Beijing", "date": "2024-01-16", "temperature_high": "-2", "temperature_low": "-8", "weather": "晴", "humidity": "30%"}</result>
+</function_results>
+
+</think>根据查询结果，明天（2024年1月16日）的天气情况如下：
+
+**杭州**：
+- 天气：多云
+- 最高温度：12°C
+- 最低温度：5°C
+- 湿度：65%
+
+**北京**：
+- 天气：晴
+- 最高温度：-2°C
+- 最低温度：-8°C
+- 湿度：30%
+
+杭州明天会比较温暖但有些多云，而北京会很冷但是晴天。建议在北京的朋友要注意保暖！<｜end▁of▁sentence｜><｜User｜>谢谢！那后天呢？<｜Assistant｜><think>用户现在问后天的天气，后天是2024-01-17，我可以直接查询（因为已知今天日期）🗓️</think>
+
+<｜DSML｜function_calls>
+<｜DSML｜invoke name="get_weather">
+<｜DSML｜parameter name="location" string="true">Hangzhou</｜DSML｜parameter>
+<｜DSML｜parameter name="date" string="true">2024-01-17</｜DSML｜parameter>
+</｜DSML｜invoke>
+<｜DSML｜invoke name="get_weather">
+<｜DSML｜parameter name="location" string="true">Beijing</｜DSML｜parameter>
+<｜DSML｜parameter name="date" string="true">2024-01-17</｜DSML｜parameter>
+</｜DSML｜invoke>
+</｜DSML｜function_calls><｜end▁of▁sentence｜>
+
+<function_results>
+<result>{"location": "Hangzhou", "date": "2024-01-17", "temperature_high": "15", "temperature_low": "8", "weather": "小雨", "humidity": "80%"}</result>
+<result>{"location": "Beijing", "date": "2024-01-17", "temperature_high": "0", "temperature_low": "-6", "weather": "多云", "humidity": "45%"}</result>
+</function_results>
+
+<think>获取到后天的天气数据，整理回复给用户📝</think>后天（2024年1月17日）的天气情况：
+
+**杭州**：
+- 天气：小雨
+- 最高温度：15°C
+- 最低温度：8°C
+- 湿度：80%
+
+**北京**：
+- 天气：多云
+- 最高温度：0°C
+- 最低温度：-6°C
+- 湿度：45%
+
+杭州后天会有小雨，温度略有回升，记得带伞。北京会稍微暖和一点，但依然很冷，请继续做好保暖措施。<｜end▁of▁sentence｜>


### PR DESCRIPTION
## Summary
- Add `attach_dsv32_encoding()` that monkey-patches `apply_chat_template()` onto a HF tokenizer using DeepSeek-V3.2's own `encoding/encoding_dsv32.py` module
- Auto-detect DeepSeek-V3.2 in `get_tokenizer()` when the encoding file is present in the tokenizer cache
- Includes incremental path for tool-result-only messages (needed for `SGLangModel`'s incremental tokenization)
- Verified output format against DeepSeek's golden test cases from HuggingFace

## Context
DeepSeek-V3.2 doesn't ship a Jinja chat template, so `tokenizer.apply_chat_template()` fails out of the box. This PR solves it at the tokenizer level, keeping `SGLangModel` unchanged and the tool parser focused on parsing.

The DeepSeek-V3.2 tool parser (`DeepSeekV32ToolParser`) and `skip_special_tokens` / `message_separator` changes will come in a follow-up PR (#23).

## Test plan
- [x] Golden reference test: wrapper output matches DeepSeek's `test_output.txt`
- [x] Transparency test: wrapper output identical to direct `encode_messages()` call
- [x] Incremental path format verified against module's `tool_output_template`
- [x] Tool attachment to existing/synthetic system message
- [x] `enable_thinking` → `thinking_mode` mapping
- [x] Input messages not mutated
- [x] Unknown kwargs emit warning
- [x] Auto-detection in `get_tokenizer()`
- [x] 20 unit tests, all passing
- [x] Ruff lint + format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)