### PR TITLE
fix: default skip_special_tokens to False for all parsers

### DIFF
--- a/src/strands_sglang/sglang.py
+++ b/src/strands_sglang/sglang.py
@@ -42,7 +42,7 @@ from typing_extensions import Unpack, override
 from .client import SGLangClient
 from .exceptions import SGLangContextLengthError, SGLangThrottledError
 from .token import TokenManager
-from .tool_parsers import DeepSeekV32ToolParser, HermesToolParser, ToolParser, ToolParseResult
+from .tool_parsers import HermesToolParser, ToolParser, ToolParseResult
 
 if TYPE_CHECKING:
     from transformers import PreTrainedTokenizerBase, ProcessorMixin
@@ -392,8 +392,7 @@ class SGLangModel(Model):
         tools = self.format_tool_specs(tool_specs) if tool_specs else None
         config = self.get_config()
         sampling_params: dict[str, Any] = dict(config.get("sampling_params") or {})
-        if isinstance(self.tool_parser, DeepSeekV32ToolParser):
-            sampling_params.setdefault("skip_special_tokens", False)
+        sampling_params.setdefault("skip_special_tokens", False)
         return_logprob = config.get("return_logprob", True)
         new_input_tokens = self.tokenize_prompt_messages(messages, system_prompt, tools=tools)
         # Tracking token IDs in token_manager to ensure the token-in feature

--- a/tests/unit/test_sglang.py
+++ b/tests/unit/test_sglang.py
@@ -489,17 +489,13 @@ class TestValidateTokenizer:
 
         parser.validate_tokenizer.assert_called_once_with(mock_tokenizer)
 
-    async def test_deepseek_parser_sets_skip_special_tokens(self, mock_tokenizer):
-        """stream() passes skip_special_tokens=False to client.generate for DeepSeek."""
+    async def test_skip_special_tokens_defaults_to_false(self, mock_tokenizer):
+        """stream() passes skip_special_tokens=False to client.generate by default."""
         from unittest.mock import AsyncMock
 
-        from strands_sglang.tool_parsers import DeepSeekV32ToolParser
-
-        mock_tokenizer._dsv32_encoding_attached = True
         client = SGLangClient(base_url="http://localhost:30000")
         client.generate = AsyncMock(return_value={"text": "hello", "output_ids": [1, 2], "meta_info": {}})
-        parser = DeepSeekV32ToolParser()
-        model = SGLangModel(client=client, tokenizer=mock_tokenizer, tool_parser=parser)
+        model = SGLangModel(client=client, tokenizer=mock_tokenizer)
 
         messages = [{"role": "user", "content": [{"text": "hi"}]}]
         async for _ in model.stream(messages):


### PR DESCRIPTION
## Summary
- Default `skip_special_tokens=False` for all tool parsers, not just `DeepSeekV32ToolParser`
- Aligns with slime's `--rollout-skip-special-tokens` default (`False`) for RL training
- Users can still override via `sampling_params` config (uses `setdefault`)

## Test plan
- [x] Unit tests pass (287/287)
- [x] Integration tests pass (65 passed, 7 VLM skipped)
- [x] Linting and formatting pass
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)