### PR TITLE
fix: use fake user prefix for incremental tokenization

### DIFF
--- a/src/strands_sglang/sglang.py
+++ b/src/strands_sglang/sglang.py
@@ -235,11 +235,9 @@ class SGLangModel(Model):
         messages: Messages,
         system_prompt: str | None = None,
         tools: list[dict] | None = None,
+        add_generation_prompt: bool = True,
     ) -> str:
-        """Format messages into a prompt ready for model generation.
-
-        Applies the HuggingFace chat template with `add_generation_prompt=True`,
-        which appends the assistant turn prefix for the model to continue.
+        """Format messages into a prompt string using the HuggingFace chat template.
 
         The result is manually tokenized (not model-generated) and added to
         the token trajectory with `loss_mask=False`.
@@ -251,7 +249,7 @@ class SGLangModel(Model):
             self.tokenizer.apply_chat_template(
                 conversation=chat_messages,
                 tools=cast(list[dict | Callable], tools),
-                add_generation_prompt=True,
+                add_generation_prompt=add_generation_prompt,
                 tokenize=False,
                 enable_thinking=self.config.get("enable_thinking"),
             )
@@ -301,10 +299,14 @@ class SGLangModel(Model):
             formatted = self.format_prompt(messages, system_prompt, tools=tools)
             return _tokenize(formatted)
 
-        # Subsequent calls: only new messages
+        # Subsequent calls: only new messages (prepend fake user to satisfy chat template assumptions).
+        # See: https://github.com/horizon-rl/strands-sglang/issues/29
         if len(messages) > self._processed_message_count:
             new_messages = self._sort_tool_results(messages[self._processed_message_count :])
-            formatted = self.tool_parser.message_separator + self.format_prompt(new_messages)
+            fake: Messages = [{"role": "user", "content": [{"text": "ONLY FOR INCREMENTAL TOKENIZATION"}]}]
+            full = self.format_prompt(fake + new_messages)
+            prefix = self.format_prompt(fake, add_generation_prompt=False)
+            formatted = self.tool_parser.message_separator + full[len(prefix) :]
             return _tokenize(formatted)
 
         return None

--- a/src/strands_sglang/utils.py
+++ b/src/strands_sglang/utils.py
@@ -140,17 +140,22 @@ def attach_dsv32_encoding(tokenizer: PreTrainedTokenizerBase) -> None:
 
         thinking_mode = "thinking" if enable_thinking else "chat"
 
-        # Incremental path: only tool results, no system/user context
-        if conversation and all(m.get("role") == "tool" for m in conversation):
+        # Incremental path: fake user prefix + tool results.
+        # See: https://github.com/horizon-rl/strands-sglang/issues/29
+        if (
+            len(conversation) >= 2
+            and conversation[0].get("role") == "user"
+            and all(m.get("role") == "tool" for m in conversation[1:])
+        ):
             result = "\n\n<function_results>"
-            for msg in conversation:
+            for msg in conversation[1:]:
                 if msg.get("role") == "tool":
                     result += "\n<result>" + msg.get("content", "") + "</result>"
             result += "\n</function_results>"
             if add_generation_prompt:
                 gen = "<think>" if thinking_mode == "thinking" else "</think>"
                 result += "\n\n" + gen
-            return result
+            return str(module.encode_messages([conversation[0]], thinking_mode=thinking_mode)) + result
 
         # Attach tools to system message (encoding module reads them from msg.get("tools"))
         messages = list(conversation)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,6 +43,12 @@ def pytest_addoption(parser):
         default=os.environ.get("SGLANG_BASE_URL", "http://localhost:30000"),
         help="SGLang server URL (default: http://localhost:30000 or SGLANG_BASE_URL env var)",
     )
+    parser.addoption(
+        "--tool-parser",
+        action="store",
+        default=os.environ.get("TOOL_PARSER", "hermes"),
+        help="Tool parser name: hermes, qwen_xml, glm, kimi_k2, deepseek_v32 (default: hermes or TOOL_PARSER env var)",
+    )
 
 
 def pytest_configure(config):

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -19,6 +19,7 @@ and require a running SGLang server.
 
 Usage:
     pytest tests/integration/ --sglang-base-url=http://localhost:30000
+    pytest tests/integration/ --sglang-base-url=http://localhost:30000 --tool-parser=qwen_xml
 
 The model ID is auto-detected from the server's /get_model_info endpoint.
 """
@@ -29,7 +30,7 @@ from transformers import AutoProcessor, AutoTokenizer, ProcessorMixin
 
 from strands_sglang import SGLangModel
 from strands_sglang.client import SGLangClient
-from strands_sglang.tool_parsers import HermesToolParser
+from strands_sglang.tool_parsers import get_tool_parser
 
 # Mark all tests in this directory as integration tests
 pytestmark = pytest.mark.integration
@@ -79,6 +80,12 @@ def sglang_base_url(sglang_server_info):
     return sglang_server_info["base_url"]
 
 
+@pytest.fixture(scope="session")
+def tool_parser_name(request):
+    """Get tool parser name from CLI option."""
+    return request.config.getoption("--tool-parser")
+
+
 @pytest.fixture(scope="module")
 def tokenizer(sglang_server_info):
     """Load tokenizer for the configured model."""
@@ -87,13 +94,13 @@ def tokenizer(sglang_server_info):
 
 
 @pytest.fixture
-async def model(tokenizer, sglang_base_url):
+async def model(tokenizer, sglang_base_url, tool_parser_name):
     """Create fresh SGLangModel for each test (perfect isolation)."""
     client = SGLangClient(base_url=sglang_base_url)
     yield SGLangModel(
         client=client,
         tokenizer=tokenizer,
-        tool_parser=HermesToolParser(),
+        tool_parser=get_tool_parser(tool_parser_name),
         sampling_params={"max_new_tokens": 32768},
     )
     await client.close()
@@ -115,7 +122,7 @@ def processor(sglang_server_info):
 
 
 @pytest.fixture
-async def vlm_model(processor, sglang_base_url):
+async def vlm_model(processor, sglang_base_url, tool_parser_name):
     """Create fresh SGLangModel with processor for VLM tests."""
     if processor is None:
         pytest.skip("Server is running a text-only model")
@@ -123,7 +130,7 @@ async def vlm_model(processor, sglang_base_url):
     yield SGLangModel(
         client=client,
         processor=processor,
-        tool_parser=HermesToolParser(),
+        tool_parser=get_tool_parser(tool_parser_name),
         sampling_params={"max_new_tokens": 32768},
     )
     await client.close()

--- a/tests/integration/test_agent_math500.py
+++ b/tests/integration/test_agent_math500.py
@@ -28,7 +28,7 @@ from strands_tools import calculator
 
 from strands_sglang import SGLangModel
 from strands_sglang.client import SGLangClient
-from strands_sglang.tool_parsers import HermesToolParser
+from strands_sglang.tool_parsers import get_tool_parser
 
 SYSTEM_PROMPT = """You are a math tutor. Always use the calculator tool to solve problems.
 
@@ -147,7 +147,7 @@ MATH500_PROBLEMS = [
 
 
 @pytest.fixture
-async def model(tokenizer, sglang_base_url):
+async def model(tokenizer, sglang_base_url, tool_parser_name):
     """Create fresh SGLangModel for each test (perfect isolation).
 
     Overrides the base model fixture to add max_new_tokens limit.
@@ -156,7 +156,7 @@ async def model(tokenizer, sglang_base_url):
     yield SGLangModel(
         client=client,
         tokenizer=tokenizer,
-        tool_parser=HermesToolParser(),
+        tool_parser=get_tool_parser(tool_parser_name),
         sampling_params={"max_new_tokens": 32768},  # High limit for thinking models
     )
     await client.close()

--- a/tests/integration/test_tool_limiter.py
+++ b/tests/integration/test_tool_limiter.py
@@ -31,7 +31,7 @@ from strands_tools import calculator
 
 from strands_sglang import MaxToolCallsReachedError, MaxToolIterationsReachedError, SGLangModel, ToolLimiter
 from strands_sglang.client import SGLangClient
-from strands_sglang.tool_parsers import HermesToolParser
+from strands_sglang.tool_parsers import get_tool_parser
 
 
 def assert_max_iterations_reached(exc_info, expected_count: int | None = None):
@@ -80,13 +80,13 @@ MULTI_CALC_PROBLEM = "Calculate 10+5, 20+10, and 30+15 using the calculator."
 
 
 @pytest.fixture
-async def fresh_model(tokenizer, sglang_base_url):
+async def fresh_model(tokenizer, sglang_base_url, tool_parser_name):
     """Create a fresh SGLangModel for each test."""
     client = SGLangClient(base_url=sglang_base_url)
     yield SGLangModel(
         client=client,
         tokenizer=tokenizer,
-        tool_parser=HermesToolParser(),
+        tool_parser=get_tool_parser(tool_parser_name),
         sampling_params={"max_new_tokens": 32768},
     )
     await client.close()

--- a/tests/unit/dsv32_tokenizer/test_dsv32_tokenizer.py
+++ b/tests/unit/dsv32_tokenizer/test_dsv32_tokenizer.py
@@ -167,29 +167,41 @@ class TestFullConversation:
 
 
 class TestIncrementalPath:
-    """Tests for incremental (tool-result-only) formatting.
+    """Tests for incremental (fake user + tool results) formatting.
 
-    The incremental path produces the same format as encode_messages()
-    renders tool messages, verified against the module's template strings.
+    The caller prepends a fake user message to satisfy the incremental path
+    detection: conversation[0] is user, conversation[1:] are all tool messages.
+    See: https://github.com/horizon-rl/strands-sglang/issues/29
     """
 
-    def test_single_tool_result(self, patched_tokenizer):
+    FAKE_USER = {"role": "user", "content": "ONLY FOR INCREMENTAL TOKENIZATION"}
+
+    def _fake_user_prefix(self, encoding_module, thinking_mode="thinking"):
+        """Return the prefix that encode_messages produces for the fake user."""
+        return encoding_module.encode_messages([self.FAKE_USER], thinking_mode=thinking_mode)
+
+    def test_single_tool_result(self, patched_tokenizer, encoding_module):
         """Single tool result matches expected format."""
-        messages = [{"role": "tool", "content": "result data"}]
+        messages = [self.FAKE_USER, {"role": "tool", "content": "result data"}]
         result = patched_tokenizer.apply_chat_template(messages, enable_thinking=True)
 
-        assert result == "\n\n<function_results>\n<result>result data</result>\n</function_results>\n\n<think>"
+        prefix = self._fake_user_prefix(encoding_module)
+        assert result == prefix + "\n\n<function_results>\n<result>result data</result>\n</function_results>\n\n<think>"
 
-    def test_multiple_tool_results(self, patched_tokenizer):
+    def test_multiple_tool_results(self, patched_tokenizer, encoding_module):
         """Multiple tool results each get their own <result> tag."""
         messages = [
+            self.FAKE_USER,
             {"role": "tool", "content": "result1"},
             {"role": "tool", "content": "result2"},
         ]
         result = patched_tokenizer.apply_chat_template(messages, enable_thinking=True)
 
+        prefix = self._fake_user_prefix(encoding_module)
         expected = (
-            "\n\n<function_results>\n<result>result1</result>\n<result>result2</result>\n</function_results>\n\n<think>"
+            prefix
+            + "\n\n<function_results>\n<result>result1</result>\n<result>result2</result>\n</function_results>"
+            + "\n\n<think>"
         )
         assert result == expected
 
@@ -197,7 +209,7 @@ class TestIncrementalPath:
         """Incremental format uses the same template strings as the encoding module."""
         content = "test content"
         result = patched_tokenizer.apply_chat_template(
-            [{"role": "tool", "content": content}],
+            [self.FAKE_USER, {"role": "tool", "content": content}],
             enable_thinking=True,
         )
 
@@ -208,7 +220,7 @@ class TestIncrementalPath:
     def test_thinking_mode_appends_think_start(self, patched_tokenizer):
         """Thinking mode appends <think> for generation prompt."""
         result = patched_tokenizer.apply_chat_template(
-            [{"role": "tool", "content": "ok"}],
+            [self.FAKE_USER, {"role": "tool", "content": "ok"}],
             enable_thinking=True,
         )
         assert result.endswith("<think>")
@@ -216,24 +228,30 @@ class TestIncrementalPath:
     def test_chat_mode_appends_think_end(self, patched_tokenizer):
         """Chat mode appends </think> — matches DeepSeek's encoding module behavior."""
         result = patched_tokenizer.apply_chat_template(
-            [{"role": "tool", "content": "ok"}],
+            [self.FAKE_USER, {"role": "tool", "content": "ok"}],
             enable_thinking=False,
         )
         assert result.endswith("</think>")
 
-    def test_no_generation_prompt(self, patched_tokenizer):
-        """No thinking tag without add_generation_prompt."""
+    def test_no_generation_prompt(self, patched_tokenizer, encoding_module):
+        """No thinking tag appended after tool results without add_generation_prompt."""
         result = patched_tokenizer.apply_chat_template(
-            [{"role": "tool", "content": "ok"}],
+            [self.FAKE_USER, {"role": "tool", "content": "ok"}],
             add_generation_prompt=False,
         )
         assert result.endswith("</function_results>")
-        assert "<think>" not in result
-        assert "</think>" not in result
+        # The fake user prefix contains <think> from encode_messages, but no thinking tag after tool results
+        prefix = self._fake_user_prefix(encoding_module)
+        incremental = result[len(prefix) :]
+        assert "<think>" not in incremental
+        assert "</think>" not in incremental
 
     def test_empty_content_defaults_to_empty_string(self, patched_tokenizer):
         """Tool result with missing content uses empty string."""
-        result = patched_tokenizer.apply_chat_template([{"role": "tool"}], enable_thinking=True)
+        result = patched_tokenizer.apply_chat_template(
+            [self.FAKE_USER, {"role": "tool"}],
+            enable_thinking=True,
+        )
         assert "<result></result>" in result
 
     def test_mixed_roles_uses_full_path(self, patched_tokenizer, encoding_module):
@@ -278,7 +296,7 @@ class TestAttachDsv32Encoding:
         """No warning when no extra kwargs passed."""
         with caplog.at_level(logging.WARNING, logger="strands_sglang.utils"):
             patched_tokenizer.apply_chat_template(
-                conversation=[{"role": "tool", "content": "ok"}],
+                conversation=[{"role": "user", "content": ""}, {"role": "tool", "content": "ok"}],
             )
 
         assert "doesn't support" not in caplog.text


### PR DESCRIPTION
## Summary
- Prepend a fake user message before tool results in incremental tokenization to satisfy Qwen3.5/Qwen3-Coder chat template assumptions (`last_query_index` validation, `loop.previtem` logic), then strip the prefix
- Update DSV3.2 incremental path to detect the `[fake_user, tool, ...]` pattern (previously detected `[tool, ...]`)
- Add `--tool-parser` CLI option for integration tests so different models' tool formats can be tested (`hermes`, `qwen_xml`, `glm`, `kimi_k2`, `deepseek_v32`)

Closes #29

## Test plan
- [x] All 287 unit tests pass (including updated DSV3.2 tokenizer tests)
- [x] Integration tests pass with `--tool-parser=qwen_xml` against Qwen3.5-4B (text mode)
- [x] Integration tests pass with `--tool-parser=hermes` against Qwen3 model

🤖 Generated with [Claude Code](https://claude.com/claude-code)