### PR TITLE
refactor: store routed_experts as raw base64 for JSON serialization

### DIFF
--- a/src/strands_sglang/sglang.py
+++ b/src/strands_sglang/sglang.py
@@ -118,7 +118,7 @@ class SGLangModel(Model):
         self.image_data = []
         self.routed_experts = None
 
-    async def decode_routed_experts(self, num_layers: int, top_k: int) -> NDArray[np.int32] | None:
+    async def decode_routed_experts(self, num_layers: int, top_k: int) -> NDArray[np.int32]:
         """Decode base64 routed experts into a shaped numpy array.
 
         Args:
@@ -126,13 +126,16 @@ class SGLangModel(Model):
             top_k: Number of experts selected per token (moe_router_topk).
 
         Returns:
-            Array of shape `(seq_len - 1, num_layers, top_k)`, or None if not available.
+            Array of shape `(seq_len - 1, num_layers, top_k)`.
         """
-        if self.routed_experts is None:
-            return None
+        assert self.routed_experts is not None, "routed_experts is None — was return_routed_experts enabled?"
         raw = self.routed_experts
-        flat = await asyncio.to_thread(lambda: np.frombuffer(pybase64.b64decode(raw.encode("ascii")), dtype=np.int32))
-        return flat.reshape(-1, num_layers, top_k)
+        seq_len = len(self.token_manager.token_ids)
+        return await asyncio.to_thread(
+            lambda: np.frombuffer(pybase64.b64decode(raw.encode("ascii")), dtype=np.int32).reshape(
+                seq_len - 1, num_layers, top_k
+            )
+        )
 
     # -------------------------------------------------------------------------
     # Model interface implementation

--- a/src/strands_sglang/sglang.py
+++ b/src/strands_sglang/sglang.py
@@ -103,10 +103,10 @@ class SGLangModel(Model):
 
         # State tracking (this makes SGLangModel stateful)
         self.token_manager = TokenManager()
+        self.routed_experts: str | None = None  # base64-encoded MoE expert indices (flat int32)
         self.message_count: int = 0
         self.tool_parse_errors: dict[str, int] = {}  # per-tool parse error count
         self.image_data: list[str] = []  # accumulated image data URLs (VLM only)
-        self.routed_experts: NDArray[np.int32] | None = None  # MoE expert indices from last /generate
 
         logger.debug("initialized with config: %s", self.config)
 
@@ -117,6 +117,22 @@ class SGLangModel(Model):
         self.tool_parse_errors = {}
         self.image_data = []
         self.routed_experts = None
+
+    async def decode_routed_experts(self, num_layers: int, top_k: int) -> NDArray[np.int32] | None:
+        """Decode base64 routed experts into a shaped numpy array.
+
+        Args:
+            num_layers: Number of MoE layers in the model.
+            top_k: Number of experts selected per token (moe_router_topk).
+
+        Returns:
+            Array of shape `(seq_len - 1, num_layers, top_k)`, or None if not available.
+        """
+        if self.routed_experts is None:
+            return None
+        raw = self.routed_experts
+        flat = await asyncio.to_thread(lambda: np.frombuffer(pybase64.b64decode(raw.encode("ascii")), dtype=np.int32))
+        return flat.reshape(-1, num_layers, top_k)
 
     # -------------------------------------------------------------------------
     # Model interface implementation
@@ -385,11 +401,9 @@ class SGLangModel(Model):
         )
         # Update routed experts for R3
         # TODO: pass routed_experts_start_len (like logprob_start_len) once SGLang wires it up,
-        # Need to reshape to (seq_len-1, num_layers, top_k) once knowing num_layers and top_k
-        if return_routed_experts:
-            self.routed_experts = await asyncio.to_thread(
-                lambda: np.frombuffer(pybase64.b64decode(meta_info["routed_experts"].encode("ascii")), dtype=np.int32)
-            )
+        # to avoid receiving the full-sequence payload on every multi-turn call.
+        self.routed_experts = meta_info["routed_experts"] if return_routed_experts else None
+        # Update message count
         self.message_count = len(messages) + 1
 
         # Assistant message content stop

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -123,11 +123,13 @@ async def vlm_model(tokenizer, sglang_base_url, tool_parser_name):
 
 
 @pytest.fixture
-async def routed_experts_model(tokenizer, sglang_base_url, tool_parser_name):
+async def routed_experts_model(tokenizer, sglang_base_url, sglang_server_info, tool_parser_name):
     """Create SGLangModel with return_routed_experts=True.
 
     Skips if the server does not support routed experts (requires MoE model
     launched with `--enable-return-routed-experts`).
+
+    Also exposes `moe_num_layers` and `moe_top_k` on the model for test assertions.
     """
     client = SGLangClient(base_url=sglang_base_url)
 
@@ -138,6 +140,11 @@ async def routed_experts_model(tokenizer, sglang_base_url, tool_parser_name):
         await client.close()
         pytest.skip("Server does not support routed experts (non-MoE model or --enable-return-routed-experts not set)")
 
+    # Infer num_layers and top_k from server info
+    hf_config = sglang_server_info.get("hf_config", {})
+    num_layers = hf_config.get("num_hidden_layers", 0)
+    top_k = hf_config.get("num_experts_per_tok", 0)
+
     model = SGLangModel(
         client=client,
         tokenizer=tokenizer,
@@ -145,6 +152,8 @@ async def routed_experts_model(tokenizer, sglang_base_url, tool_parser_name):
         sampling_params={"max_new_tokens": 2048},
         return_routed_experts=True,
     )
+    model.moe_num_layers = num_layers
+    model.moe_top_k = top_k
     yield model
     await client.close()
 

--- a/tests/integration/test_routed_experts.py
+++ b/tests/integration/test_routed_experts.py
@@ -14,62 +14,60 @@
 
 """Integration tests for MoE routed experts capture (R3)."""
 
+import json
+
 import numpy as np
+import pytest
+from strands import Agent
 
 
-async def test_routed_experts_single_turn(routed_experts_model):
-    """Single-turn generation captures routed experts as base64 string and decodes correctly."""
+async def test_single_turn_base64_and_decode(routed_experts_model):
+    """Single-turn: routed_experts is base64, decode_routed_experts returns correct shape."""
     model = routed_experts_model
     messages = [{"role": "user", "content": [{"text": "Say 'hello' and nothing else."}]}]
 
     async for _ in model.stream(messages, system_prompt="Be brief."):
         pass
 
-    assert model.routed_experts is not None
+    # Raw value is a base64 string
     assert isinstance(model.routed_experts, str)
 
-    # Verify raw base64 decodes to int32 array divisible by (total_tokens - 1)
-    total_tokens = len(model.token_manager.token_ids)
-    raw_array = np.frombuffer(__import__("pybase64").b64decode(model.routed_experts.encode("ascii")), dtype=np.int32)
-    assert len(raw_array) % (total_tokens - 1) == 0
+    # JSON-serializable (needed for Ray actor transport)
+    json.dumps({"routed_experts": model.routed_experts})
+
+    # decode_routed_experts returns correct shape
+    if model.moe_num_layers and model.moe_top_k:
+        decoded = await model.decode_routed_experts(num_layers=model.moe_num_layers, top_k=model.moe_top_k)
+        total_tokens = len(model.token_manager.token_ids)
+        assert decoded.shape == (total_tokens - 1, model.moe_num_layers, model.moe_top_k)
+        assert decoded.dtype == np.int32
 
 
-async def test_routed_experts_multi_turn(routed_experts_model, calculator_tool):
-    """Multi-turn tool use updates routed experts on each generation call."""
+async def test_multi_turn_agent_with_tools(routed_experts_model):
+    """Multi-turn agent loop: routed_experts covers the full trajectory."""
     model = routed_experts_model
-    system_prompt = "You are a calculator. Use the calculator tool for ALL math."
 
-    # Turn 1
-    messages = [{"role": "user", "content": [{"text": "What is 5 * 8?"}]}]
-    async for _ in model.stream(messages, tool_specs=[calculator_tool], system_prompt=system_prompt):
-        pass
+    def calculator(expression: str) -> str:
+        """Evaluate a math expression."""
+        return str(eval(expression))  # noqa: S307
 
-    experts_turn1 = model.routed_experts
-    assert experts_turn1 is not None
-
-    # Inject tool result for turn 2
-    messages.append(
-        {
-            "role": "assistant",
-            "content": [
-                {"text": '<tool_call>\n{"name": "calculator", "arguments": {"expression": "5 * 8"}}\n</tool_call>'},
-                {"toolUse": {"toolUseId": "call_1", "name": "calculator", "input": {"expression": "5 * 8"}}},
-            ],
-        }
+    agent = Agent(
+        model=model,
+        tools=[calculator],
+        system_prompt="Use the calculator tool for ALL math. Be brief.",
     )
-    messages.append({"role": "user", "content": [{"toolResult": {"toolUseId": "call_1", "content": [{"text": "40"}]}}]})
+    await agent.invoke_async("What is 137 * 251?")
 
-    # Turn 2
-    async for _ in model.stream(messages, tool_specs=[calculator_tool], system_prompt=system_prompt):
-        pass
+    assert model.routed_experts is not None
+    total_tokens = len(model.token_manager.token_ids)
+    assert total_tokens > 10  # sanity: multi-turn should produce many tokens
 
-    experts_turn2 = model.routed_experts
-    assert experts_turn2 is not None
-    # Turn 2 covers more tokens (full sequence), so the base64 string should be longer
-    assert len(experts_turn2) > len(experts_turn1)
+    if model.moe_num_layers and model.moe_top_k:
+        decoded = await model.decode_routed_experts(num_layers=model.moe_num_layers, top_k=model.moe_top_k)
+        assert decoded.shape == (total_tokens - 1, model.moe_num_layers, model.moe_top_k)
 
 
-async def test_routed_experts_reset(routed_experts_model):
+async def test_reset_clears(routed_experts_model):
     """reset() clears routed experts."""
     model = routed_experts_model
     messages = [{"role": "user", "content": [{"text": "Hi"}]}]
@@ -78,6 +76,13 @@ async def test_routed_experts_reset(routed_experts_model):
         pass
 
     assert model.routed_experts is not None
-
     model.reset()
     assert model.routed_experts is None
+
+
+async def test_decode_fails_when_none(routed_experts_model):
+    """decode_routed_experts raises when routed_experts is None."""
+    model = routed_experts_model
+    model.reset()
+    with pytest.raises(AssertionError, match="routed_experts is None"):
+        await model.decode_routed_experts(num_layers=1, top_k=1)

--- a/tests/integration/test_routed_experts.py
+++ b/tests/integration/test_routed_experts.py
@@ -18,7 +18,7 @@ import numpy as np
 
 
 async def test_routed_experts_single_turn(routed_experts_model):
-    """Single-turn generation captures routed experts as int32 numpy array."""
+    """Single-turn generation captures routed experts as base64 string."""
     model = routed_experts_model
     messages = [{"role": "user", "content": [{"text": "Say 'hello' and nothing else."}]}]
 
@@ -26,12 +26,14 @@ async def test_routed_experts_single_turn(routed_experts_model):
         pass
 
     assert model.routed_experts is not None
-    assert model.routed_experts.dtype == np.int32
-    assert len(model.routed_experts) > 0
+    assert isinstance(model.routed_experts, str)
 
-    # Shape: (total_tokens - 1) * num_layers * moe_router_topk elements
+    # Decode and verify shape: (total_tokens - 1) * num_layers * moe_router_topk elements
+    decoded = await model.decode_routed_experts(num_layers=24, top_k=4)
+    assert decoded is not None
+    assert decoded.dtype == np.int32
     total_tokens = len(model.token_manager.token_ids)
-    assert len(model.routed_experts) % (total_tokens - 1) == 0
+    assert decoded.shape[0] == total_tokens - 1
 
 
 async def test_routed_experts_multi_turn(routed_experts_model, calculator_tool):
@@ -65,7 +67,7 @@ async def test_routed_experts_multi_turn(routed_experts_model, calculator_tool):
 
     experts_turn2 = model.routed_experts
     assert experts_turn2 is not None
-    # Turn 2 covers more tokens (full sequence), so the array should be larger
+    # Turn 2 covers more tokens (full sequence), so the base64 string should be longer
     assert len(experts_turn2) > len(experts_turn1)
 
 

--- a/tests/integration/test_routed_experts.py
+++ b/tests/integration/test_routed_experts.py
@@ -18,7 +18,7 @@ import numpy as np
 
 
 async def test_routed_experts_single_turn(routed_experts_model):
-    """Single-turn generation captures routed experts as base64 string."""
+    """Single-turn generation captures routed experts as base64 string and decodes correctly."""
     model = routed_experts_model
     messages = [{"role": "user", "content": [{"text": "Say 'hello' and nothing else."}]}]
 
@@ -28,12 +28,10 @@ async def test_routed_experts_single_turn(routed_experts_model):
     assert model.routed_experts is not None
     assert isinstance(model.routed_experts, str)
 
-    # Decode and verify shape: (total_tokens - 1) * num_layers * moe_router_topk elements
-    decoded = await model.decode_routed_experts(num_layers=24, top_k=4)
-    assert decoded is not None
-    assert decoded.dtype == np.int32
+    # Verify raw base64 decodes to int32 array divisible by (total_tokens - 1)
     total_tokens = len(model.token_manager.token_ids)
-    assert decoded.shape[0] == total_tokens - 1
+    raw_array = np.frombuffer(__import__("pybase64").b64decode(model.routed_experts.encode("ascii")), dtype=np.int32)
+    assert len(raw_array) % (total_tokens - 1) == 0
 
 
 async def test_routed_experts_multi_turn(routed_experts_model, calculator_tool):

--- a/tests/unit/test_sglang.py
+++ b/tests/unit/test_sglang.py
@@ -291,6 +291,29 @@ class TestStreamRoutedExperts:
 
         assert model.routed_experts == encoded
 
+    async def test_decode_routed_experts(self, mock_tokenizer):
+        """decode_routed_experts() decodes base64 to shaped numpy array."""
+        num_layers, top_k = 4, 2
+        # Mock generates output_ids=[1, 2], prompt encodes to [100, 101, 102]
+        # total token_ids = [100, 101, 102, 1, 2] → seq_len - 1 = 4
+        mock_tokenizer.encode.return_value = [100, 101, 102]
+        mock_tokenizer.apply_chat_template.return_value = "<|im_start|>user\nhi<|im_end|>\n<|im_start|>assistant\n"
+        experts = np.arange(4 * num_layers * top_k, dtype=np.int32)
+        encoded = pybase64.b64encode(experts.tobytes()).decode("ascii")
+
+        response = _make_generate_response()
+        response["meta_info"]["routed_experts"] = encoded
+
+        model, _ = _make_model_with_mock_client(mock_tokenizer, generate_return=response, return_routed_experts=True)
+
+        messages = [{"role": "user", "content": [{"text": "hi"}]}]
+        async for _ in model.stream(messages):
+            pass
+
+        decoded = await model.decode_routed_experts(num_layers=num_layers, top_k=top_k)
+        assert decoded.shape == (4, num_layers, top_k)
+        np.testing.assert_array_equal(decoded.ravel(), experts)
+
     async def test_raises_when_not_in_response(self, mock_tokenizer):
         """stream() raises KeyError when return_routed_experts=True but server omits it."""
         model, _ = _make_model_with_mock_client(mock_tokenizer, return_routed_experts=True)

--- a/tests/unit/test_sglang.py
+++ b/tests/unit/test_sglang.py
@@ -275,8 +275,8 @@ class TestStreamRoutedExperts:
 
         assert client.generate.call_args.kwargs["return_routed_experts"] is False
 
-    async def test_decoded_and_stored(self, mock_tokenizer):
-        """stream() decodes routed_experts from meta_info and stores on model."""
+    async def test_stored_as_base64(self, mock_tokenizer):
+        """stream() stores routed_experts as raw base64 string from meta_info."""
         experts_array = np.arange(36, dtype=np.int32)
         encoded = pybase64.b64encode(experts_array.tobytes()).decode("ascii")
 
@@ -289,7 +289,7 @@ class TestStreamRoutedExperts:
         async for _ in model.stream(messages):
             pass
 
-        np.testing.assert_array_equal(model.routed_experts, experts_array)
+        assert model.routed_experts == encoded
 
     async def test_raises_when_not_in_response(self, mock_tokenizer):
         """stream() raises KeyError when return_routed_experts=True but server omits it."""


### PR DESCRIPTION
## Summary

- Store `routed_experts` on `SGLangModel` as the raw base64 `str` from SGLang instead of eagerly decoding to numpy. This makes it JSON-serializable, which is required for distributed Ray actor communication (`model_dump_json()` / `model_validate_json()`).
- Add `decode_routed_experts(num_layers, top_k)` async utility method for consumers that need the shaped `(seq_len-1, num_layers, top_k)` numpy array.
- Use `meta_info["routed_experts"]` (KeyError on missing) instead of `.get()` to surface server misconfiguration early.

## Motivation

In RufusGym's distributed agentic RL path, `StepResult` is serialized to JSON via Pydantic for transport between Ray actors. The previous numpy array caused `PydanticSerializationError: Unable to serialize unknown type: <class 'numpy.ndarray'>`. Storing as base64 string avoids this while keeping the decode path available via the utility method.

## Test plan

- [x] Unit tests updated and passing (`test_stored_as_base64`, `test_decode_routed_experts`)
- [x] Integration tests rewritten with agent tool-calling loop against live MoE server
- [x] `test_decode_fails_when_none` — clear assertion error when called without data

🤖 Generated with [Claude Code](https://claude.com/claude-code)