### PR TITLE
refactor: extract decode_routed_experts as standalone utility

### DIFF
--- a/src/strands_sglang/__init__.py
+++ b/src/strands_sglang/__init__.py
@@ -27,10 +27,11 @@ from .sglang import SGLangModel
 from .token import Token, TokenManager
 from .tool_limiter import MaxToolCallsReachedError, MaxToolIterationsReachedError, ToolLimiter
 from .tool_parsers import get_tool_parser
-from .utils import get_client, get_client_from_slime_args, get_tokenizer
+from .utils import decode_routed_experts, get_client, get_client_from_slime_args, get_tokenizer
 
 __all__ = [
-    # Cache utilities
+    # Utilities
+    "decode_routed_experts",
     "get_client",
     "get_client_from_slime_args",
     "get_tokenizer",

--- a/src/strands_sglang/sglang.py
+++ b/src/strands_sglang/sglang.py
@@ -16,7 +16,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import json
 import logging
 from collections.abc import AsyncGenerator, AsyncIterable
@@ -28,9 +27,7 @@ from typing import (
     cast,
 )
 
-import numpy as np
 import pybase64
-from numpy.typing import NDArray
 from pydantic import BaseModel
 from strands.models import Model
 from strands.types.content import ContentBlock, Messages, SystemContentBlock
@@ -117,25 +114,6 @@ class SGLangModel(Model):
         self.tool_parse_errors = {}
         self.image_data = []
         self.routed_experts = None
-
-    async def decode_routed_experts(self, num_layers: int, top_k: int) -> NDArray[np.int32]:
-        """Decode base64 routed experts into a shaped numpy array.
-
-        Args:
-            num_layers: Number of MoE layers in the model.
-            top_k: Number of experts selected per token (moe_router_topk).
-
-        Returns:
-            Array of shape `(seq_len - 1, num_layers, top_k)`.
-        """
-        assert self.routed_experts is not None, "routed_experts is None — was return_routed_experts enabled?"
-        raw = self.routed_experts
-        seq_len = len(self.token_manager.token_ids)
-        return await asyncio.to_thread(
-            lambda: np.frombuffer(pybase64.b64decode(raw.encode("ascii")), dtype=np.int32).reshape(
-                seq_len - 1, num_layers, top_k
-            )
-        )
 
     # -------------------------------------------------------------------------
     # Model interface implementation

--- a/src/strands_sglang/utils.py
+++ b/src/strands_sglang/utils.py
@@ -20,6 +20,10 @@ import logging
 from functools import cache
 from typing import TYPE_CHECKING, Any
 
+import numpy as np
+import pybase64
+from numpy.typing import NDArray
+
 from .client import DEFAULT_MAX_CONNECTIONS, SGLangClient
 
 logger = logging.getLogger(__name__)
@@ -80,3 +84,20 @@ def get_tokenizer(tokenizer_path: str) -> PreTrainedTokenizerBase:
     from transformers import AutoTokenizer
 
     return AutoTokenizer.from_pretrained(tokenizer_path, trust_remote_code=True)
+
+
+def decode_routed_experts(routed_experts: str, seq_len: int, num_layers: int, top_k: int) -> NDArray[np.int32]:
+    """Decode base64-encoded routed experts into a shaped numpy array.
+
+    Args:
+        routed_experts: Base64-encoded string of int32 expert indices from SGLang.
+        seq_len: Total number of tokens in the sequence.
+        num_layers: Number of MoE layers in the model.
+        top_k: Number of experts selected per token (moe_router_topk).
+
+    Returns:
+        Array of shape `(seq_len - 1, num_layers, top_k)`.
+    """
+    return np.frombuffer(pybase64.b64decode(routed_experts.encode("ascii")), dtype=np.int32).reshape(
+        seq_len - 1, num_layers, top_k
+    )

--- a/tests/integration/test_routed_experts.py
+++ b/tests/integration/test_routed_experts.py
@@ -17,8 +17,8 @@
 import json
 
 import numpy as np
-import pytest
-from strands import Agent
+
+from strands_sglang import decode_routed_experts
 
 
 async def test_single_turn_base64_and_decode(routed_experts_model):
@@ -37,33 +37,53 @@ async def test_single_turn_base64_and_decode(routed_experts_model):
 
     # decode_routed_experts returns correct shape
     if model.moe_num_layers and model.moe_top_k:
-        decoded = await model.decode_routed_experts(num_layers=model.moe_num_layers, top_k=model.moe_top_k)
         total_tokens = len(model.token_manager.token_ids)
+        decoded = decode_routed_experts(
+            model.routed_experts, seq_len=total_tokens, num_layers=model.moe_num_layers, top_k=model.moe_top_k
+        )
         assert decoded.shape == (total_tokens - 1, model.moe_num_layers, model.moe_top_k)
         assert decoded.dtype == np.int32
 
 
-async def test_multi_turn_agent_with_tools(routed_experts_model):
-    """Multi-turn agent loop: routed_experts covers the full trajectory."""
+async def test_multi_turn_agent_with_tools(routed_experts_model, calculator_tool):
+    """Multi-turn tool use updates routed experts across turns."""
     model = routed_experts_model
+    system_prompt = "You are a calculator. Use the calculator tool for ALL math."
 
-    def calculator(expression: str) -> str:
-        """Evaluate a math expression."""
-        return str(eval(expression))  # noqa: S307
+    # Turn 1: model should produce a tool call
+    messages = [{"role": "user", "content": [{"text": "What is 5 * 8?"}]}]
+    async for _ in model.stream(messages, tool_specs=[calculator_tool], system_prompt=system_prompt):
+        pass
 
-    agent = Agent(
-        model=model,
-        tools=[calculator],
-        system_prompt="Use the calculator tool for ALL math. Be brief.",
+    experts_turn1 = model.routed_experts
+    assert experts_turn1 is not None
+
+    # Inject tool result for turn 2
+    messages.append(
+        {
+            "role": "assistant",
+            "content": [
+                {"text": '<tool_call>\n{"name": "calculator", "arguments": {"expression": "5 * 8"}}\n</tool_call>'},
+                {"toolUse": {"toolUseId": "call_1", "name": "calculator", "input": {"expression": "5 * 8"}}},
+            ],
+        }
     )
-    await agent.invoke_async("What is 137 * 251?")
+    messages.append({"role": "user", "content": [{"toolResult": {"toolUseId": "call_1", "content": [{"text": "40"}]}}]})
 
-    assert model.routed_experts is not None
-    total_tokens = len(model.token_manager.token_ids)
-    assert total_tokens > 10  # sanity: multi-turn should produce many tokens
+    # Turn 2: model should produce final answer
+    async for _ in model.stream(messages, tool_specs=[calculator_tool], system_prompt=system_prompt):
+        pass
+
+    experts_turn2 = model.routed_experts
+    assert experts_turn2 is not None
+    # Turn 2 covers more tokens (full sequence), so the base64 string should be longer
+    assert len(experts_turn2) > len(experts_turn1)
 
     if model.moe_num_layers and model.moe_top_k:
-        decoded = await model.decode_routed_experts(num_layers=model.moe_num_layers, top_k=model.moe_top_k)
+        total_tokens = len(model.token_manager.token_ids)
+        decoded = decode_routed_experts(
+            experts_turn2, seq_len=total_tokens, num_layers=model.moe_num_layers, top_k=model.moe_top_k
+        )
         assert decoded.shape == (total_tokens - 1, model.moe_num_layers, model.moe_top_k)
 
 
@@ -78,11 +98,3 @@ async def test_reset_clears(routed_experts_model):
     assert model.routed_experts is not None
     model.reset()
     assert model.routed_experts is None
-
-
-async def test_decode_fails_when_none(routed_experts_model):
-    """decode_routed_experts raises when routed_experts is None."""
-    model = routed_experts_model
-    model.reset()
-    with pytest.raises(AssertionError, match="routed_experts is None"):
-        await model.decode_routed_experts(num_layers=1, top_k=1)

--- a/tests/unit/test_sglang.py
+++ b/tests/unit/test_sglang.py
@@ -291,27 +291,16 @@ class TestStreamRoutedExperts:
 
         assert model.routed_experts == encoded
 
-    async def test_decode_routed_experts(self, mock_tokenizer):
+    def test_decode_routed_experts_util(self):
         """decode_routed_experts() decodes base64 to shaped numpy array."""
-        num_layers, top_k = 4, 2
-        # Mock generates output_ids=[1, 2], prompt encodes to [100, 101, 102]
-        # total token_ids = [100, 101, 102, 1, 2] → seq_len - 1 = 4
-        mock_tokenizer.encode.return_value = [100, 101, 102]
-        mock_tokenizer.apply_chat_template.return_value = "<|im_start|>user\nhi<|im_end|>\n<|im_start|>assistant\n"
-        experts = np.arange(4 * num_layers * top_k, dtype=np.int32)
+        from strands_sglang import decode_routed_experts
+
+        num_layers, top_k, seq_len = 4, 2, 5
+        experts = np.arange((seq_len - 1) * num_layers * top_k, dtype=np.int32)
         encoded = pybase64.b64encode(experts.tobytes()).decode("ascii")
 
-        response = _make_generate_response()
-        response["meta_info"]["routed_experts"] = encoded
-
-        model, _ = _make_model_with_mock_client(mock_tokenizer, generate_return=response, return_routed_experts=True)
-
-        messages = [{"role": "user", "content": [{"text": "hi"}]}]
-        async for _ in model.stream(messages):
-            pass
-
-        decoded = await model.decode_routed_experts(num_layers=num_layers, top_k=top_k)
-        assert decoded.shape == (4, num_layers, top_k)
+        decoded = decode_routed_experts(encoded, seq_len=seq_len, num_layers=num_layers, top_k=top_k)
+        assert decoded.shape == (seq_len - 1, num_layers, top_k)
         np.testing.assert_array_equal(decoded.ravel(), experts)
 
     async def test_raises_when_not_in_response(self, mock_tokenizer):


### PR DESCRIPTION
## Summary

- Move `decode_routed_experts()` from `SGLangModel` method to standalone function in `utils.py`
- Export from `strands_sglang` package so consumers can `from strands_sglang import decode_routed_experts`
- Remove the method from `SGLangModel` — the model just stores the raw base64 string

## Motivation

Consumers only have the base64 string for serialization, so they can't call the method with the `SGLangModel` instance. A standalone function avoids reimplementing the decode + reshape logic.

## Test plan

- [x] Unit test: `test_decode_routed_experts_util` — verifies shape and values
- [x] Integration tests: all 3 pass against live MoE server (single-turn, multi-turn with tool calls, reset)

🤖 Generated with [Claude Code](https://claude.com/claude-code)