### PR TITLE
chore: rename organization from Horizon RL to Strands RL

### DIFF
--- a/.license-header.txt
+++ b/.license-header.txt
@@ -1,4 +1,4 @@
-Copyright 2025-2026 Horizon RL Contributors
+Copyright 2025-2026 Strands RL Contributors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2025-2026 Horizon RL Contributors
+   Copyright 2025-2026 Strands RL Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/examples/math_agent.py
+++ b/examples/math_agent.py
@@ -1,4 +1,4 @@
-# Copyright 2025-2026 Horizon RL Contributors
+# Copyright 2025-2026 Strands RL Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/retokenization_drift/main.py
+++ b/examples/retokenization_drift/main.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright 2025-2026 Horizon RL Contributors
+# Copyright 2025-2026 Strands RL Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/structured_output.py
+++ b/examples/structured_output.py
@@ -1,4 +1,4 @@
-# Copyright 2025-2026 Horizon RL Contributors
+# Copyright 2025-2026 Strands RL Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/vlm_agent/vlm_agent.py
+++ b/examples/vlm_agent/vlm_agent.py
@@ -1,4 +1,4 @@
-# Copyright 2025-2026 Horizon RL Contributors
+# Copyright 2025-2026 Strands RL Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/strands_sglang/__init__.py
+++ b/src/strands_sglang/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2025-2026 Horizon RL Contributors
+# Copyright 2025-2026 Strands RL Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/strands_sglang/client.py
+++ b/src/strands_sglang/client.py
@@ -1,4 +1,4 @@
-# Copyright 2025-2026 Horizon RL Contributors
+# Copyright 2025-2026 Strands RL Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/strands_sglang/exceptions.py
+++ b/src/strands_sglang/exceptions.py
@@ -1,4 +1,4 @@
-# Copyright 2025-2026 Horizon RL Contributors
+# Copyright 2025-2026 Strands RL Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/strands_sglang/sglang.py
+++ b/src/strands_sglang/sglang.py
@@ -1,4 +1,4 @@
-# Copyright 2025-2026 Horizon RL Contributors
+# Copyright 2025-2026 Strands RL Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/strands_sglang/token.py
+++ b/src/strands_sglang/token.py
@@ -1,4 +1,4 @@
-# Copyright 2025-2026 Horizon RL Contributors
+# Copyright 2025-2026 Strands RL Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/strands_sglang/tool_limiter.py
+++ b/src/strands_sglang/tool_limiter.py
@@ -1,4 +1,4 @@
-# Copyright 2025-2026 Horizon RL Contributors
+# Copyright 2025-2026 Strands RL Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/strands_sglang/tool_parsers/__init__.py
+++ b/src/strands_sglang/tool_parsers/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2025-2026 Horizon RL Contributors
+# Copyright 2025-2026 Strands RL Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/strands_sglang/tool_parsers/base.py
+++ b/src/strands_sglang/tool_parsers/base.py
@@ -1,4 +1,4 @@
-# Copyright 2025-2026 Horizon RL Contributors
+# Copyright 2025-2026 Strands RL Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/strands_sglang/tool_parsers/glm.py
+++ b/src/strands_sglang/tool_parsers/glm.py
@@ -1,4 +1,4 @@
-# Copyright 2025-2026 Horizon RL Contributors
+# Copyright 2025-2026 Strands RL Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/strands_sglang/tool_parsers/hermes.py
+++ b/src/strands_sglang/tool_parsers/hermes.py
@@ -1,4 +1,4 @@
-# Copyright 2025-2026 Horizon RL Contributors
+# Copyright 2025-2026 Strands RL Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/strands_sglang/tool_parsers/kimi_k2.py
+++ b/src/strands_sglang/tool_parsers/kimi_k2.py
@@ -1,4 +1,4 @@
-# Copyright 2025-2026 Horizon RL Contributors
+# Copyright 2025-2026 Strands RL Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/strands_sglang/tool_parsers/qwen_xml.py
+++ b/src/strands_sglang/tool_parsers/qwen_xml.py
@@ -1,4 +1,4 @@
-# Copyright 2025-2026 Horizon RL Contributors
+# Copyright 2025-2026 Strands RL Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/strands_sglang/utils.py
+++ b/src/strands_sglang/utils.py
@@ -1,4 +1,4 @@
-# Copyright 2025-2026 Horizon RL Contributors
+# Copyright 2025-2026 Strands RL Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2025-2026 Horizon RL Contributors
+# Copyright 2025-2026 Strands RL Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
-# Copyright 2025-2026 Horizon RL Contributors
+# Copyright 2025-2026 Strands RL Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2025-2026 Horizon RL Contributors
+# Copyright 2025-2026 Strands RL Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,4 +1,4 @@
-# Copyright 2025-2026 Horizon RL Contributors
+# Copyright 2025-2026 Strands RL Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/integration/test_chat_templates.py
+++ b/tests/integration/test_chat_templates.py
@@ -1,4 +1,4 @@
-# Copyright 2025-2026 Horizon RL Contributors
+# Copyright 2025-2026 Strands RL Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/integration/test_client_errors.py
+++ b/tests/integration/test_client_errors.py
@@ -1,4 +1,4 @@
-# Copyright 2025-2026 Horizon RL Contributors
+# Copyright 2025-2026 Strands RL Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/integration/test_routed_experts.py
+++ b/tests/integration/test_routed_experts.py
@@ -1,4 +1,4 @@
-# Copyright 2025-2026 Horizon RL Contributors
+# Copyright 2025-2026 Strands RL Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/integration/test_sglang_agent.py
+++ b/tests/integration/test_sglang_agent.py
@@ -1,4 +1,4 @@
-# Copyright 2025-2026 Horizon RL Contributors
+# Copyright 2025-2026 Strands RL Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/integration/test_sglang_text.py
+++ b/tests/integration/test_sglang_text.py
@@ -1,4 +1,4 @@
-# Copyright 2025-2026 Horizon RL Contributors
+# Copyright 2025-2026 Strands RL Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/integration/test_sglang_vision.py
+++ b/tests/integration/test_sglang_vision.py
@@ -1,4 +1,4 @@
-# Copyright 2025-2026 Horizon RL Contributors
+# Copyright 2025-2026 Strands RL Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/integration/test_structured_output.py
+++ b/tests/integration/test_structured_output.py
@@ -1,4 +1,4 @@
-# Copyright 2025-2026 Horizon RL Contributors
+# Copyright 2025-2026 Strands RL Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/integration/test_tool_limiter.py
+++ b/tests/integration/test_tool_limiter.py
@@ -1,4 +1,4 @@
-# Copyright 2025-2026 Horizon RL Contributors
+# Copyright 2025-2026 Strands RL Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2025-2026 Horizon RL Contributors
+# Copyright 2025-2026 Strands RL Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -1,4 +1,4 @@
-# Copyright 2025-2026 Horizon RL Contributors
+# Copyright 2025-2026 Strands RL Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit/test_messages.py
+++ b/tests/unit/test_messages.py
@@ -1,4 +1,4 @@
-# Copyright 2025-2026 Horizon RL Contributors
+# Copyright 2025-2026 Strands RL Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit/test_sglang.py
+++ b/tests/unit/test_sglang.py
@@ -1,4 +1,4 @@
-# Copyright 2025-2026 Horizon RL Contributors
+# Copyright 2025-2026 Strands RL Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit/test_token.py
+++ b/tests/unit/test_token.py
@@ -1,4 +1,4 @@
-# Copyright 2025-2026 Horizon RL Contributors
+# Copyright 2025-2026 Strands RL Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit/test_tool_limiter.py
+++ b/tests/unit/test_tool_limiter.py
@@ -1,4 +1,4 @@
-# Copyright 2025-2026 Horizon RL Contributors
+# Copyright 2025-2026 Strands RL Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit/test_tool_parser.py
+++ b/tests/unit/test_tool_parser.py
@@ -1,4 +1,4 @@
-# Copyright 2025-2026 Horizon RL Contributors
+# Copyright 2025-2026 Strands RL Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,4 +1,4 @@
-# Copyright 2025-2026 Horizon RL Contributors
+# Copyright 2025-2026 Strands RL Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit/test_vlm.py
+++ b/tests/unit/test_vlm.py
@@ -1,4 +1,4 @@
-# Copyright 2025-2026 Horizon RL Contributors
+# Copyright 2025-2026 Strands RL Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Summary
- Replace all "Horizon RL" references with "Strands RL" in copyright headers, LICENSE, and `.license-header.txt` (40 files)

## Test plan
- [x] Verified no remaining "Horizon RL" occurrences via grep
- [x] Pre-commit hooks passed (ruff, mypy, unit tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)