### PR TITLE
feat: add Rollout.initial_prompt_length property

### DIFF
--- a/src/strands_sglang/rollout.py
+++ b/src/strands_sglang/rollout.py
@@ -80,6 +80,11 @@ class Rollout(BaseModel):
         buffer = b"".join(pybase64.b64decode(s.encode("ascii")) for s in self.routed_experts)
         return np.frombuffer(buffer, dtype=np.int32).reshape(-1, num_layers, top_k)
 
+    @property
+    def initial_prompt_length(self) -> int:
+        """Return the length of the initial prompt."""
+        return self.segment_info[0][1] if self.segment_info else 0
+
     def __len__(self) -> int:
         """Return the total number of tokens."""
         return len(self.token_ids)


### PR DESCRIPTION
## What

Adds an `initial_prompt_length` property to `Rollout`, derived from `segment_info`:

```python
@property
def initial_prompt_length(self) -> int:
    """Return the length of the initial prompt."""
    return self.segment_info[0][1] if self.segment_info else 0
```

## Why

The first segment of a rollout is always the initial prompt (system + user), tokenized as one segment. Exposing its length lets consumers split a rollout into prompt vs. response tokens (e.g. `token_ids[:initial_prompt_length]` / `token_ids[initial_prompt_length:]`) without reaching into `segment_info` directly.

This replaces the prompt/response slicing that previously lived on `strands-env`'s `TokenObservation` (now being retired in favor of holding a `Rollout` directly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)