### PR TITLE
fix: cast tokenizer.decode result to str for transformers 5.x

### DIFF
--- a/src/strands_sglang/sglang.py
+++ b/src/strands_sglang/sglang.py
@@ -144,7 +144,7 @@ class SGLangModel(Model):
             )
         )
         sep = self.tokenizer.encode(probe.split("__M__", 1)[1], add_special_tokens=False)[1:]
-        return self.tokenizer.decode(sep) if sep else ""
+        return str(self.tokenizer.decode(sep)) if sep else ""
 
     @classmethod
     def format_content_block(


### PR DESCRIPTION
## Summary

Follow-up to #69 (transformers bump to 5.6+). transformers 5.x annotates `PreTrainedTokenizer.decode` as returning `str | list[str]`, which fails mypy against `message_separator`'s `-> str` return type:

```
src/strands_sglang/sglang.py:147: error: Incompatible return value type (got "str | list[str]", expected "str")  [return-value]
```

Wraps the `decode()` call in `str(...)`, matching the existing `apply_chat_template(...)` handling two lines above.

## Test plan

- [x] `mypy src/strands_sglang/` passes (failed before this change)
- [x] Pre-commit hooks pass (ruff, mypy, unit tests, conventional commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)