### PR TITLE
ci: bump GitHub Actions to Node 24 majors + pin mypy<2 to fix lint

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,10 +11,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -28,7 +28,7 @@ jobs:
         run: twine check dist/*
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dist
           path: dist/
@@ -42,7 +42,7 @@ jobs:
 
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,10 +13,10 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -42,15 +42,15 @@ jobs:
         python-version: ["3.10", "3.11", "3.12"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Cache pip dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('pyproject.toml') }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dev = [
     # Linting & Build
     "pre-commit",
     "ruff>=0.6.0",
-    "mypy>=1.10.0",
+    "mypy>=1.15.0,<2.0.0",
     "twine>=4.0.0",
     "build>=0.10.0",
     # Development
@@ -93,7 +93,7 @@ ignore = ["E501"]
 convention = "google"
 
 [tool.mypy]
-python_version = "3.10"
+python_version = "3.12"
 warn_unused_configs = true
 disallow_untyped_defs = true
 disallow_incomplete_defs = true


### PR DESCRIPTION
## What

Two CI-hygiene fixes for both workflows + the mypy toolchain:

### 1. Bump official actions to their Node-24 majors

| Action | Before | After |
|--------|--------|-------|
| `actions/checkout` | v4 | v7 |
| `actions/setup-python` | v5 | v6 |
| `actions/upload-artifact` | v4 | v7 |
| `actions/download-artifact` | v4 | v8 |
| `actions/cache` | v4 | v5 |

GitHub is deprecating the Node.js 20 runtime; the pinned `@v4`/`@v5` majors target it and get force-run on Node 24 with a deprecation annotation. These bumps move every official action to a major that runs on Node 24 natively. Mirrors strands-rl/strands-env#162.

### 2. Pin `mypy>=1.15.0,<2.0.0` and target Python 3.12 (`fix: mypy versioning`)

The unbounded `mypy>=1.10.0` let CI resolve **mypy 2.1.0**, which — together with the sub-3.12 mypy target — rejected numpy ≥2.5's PEP 695 `type` stubs (`numpy/__init__.pyi: Type statement is only supported in Python 3.12 and greater`), aborting lint before it checked any source. Pinning `mypy<2` and moving the target to **3.12** unbreaks the (pre-existing, repo-wide) lint failure. Mirrors strands-rl/strands-env#161. Runtime support for 3.10/3.11 stays covered by the test matrix.

## Notes

- All bumped actions require a minimum Actions Runner of `2.327.1`; GitHub-hosted `ubuntu-latest` runners exceed this.
- `download-artifact@v8`'s behavioral changes (hash-mismatch-errors-by-default, ESM, skip-decompress for non-zip) don't affect the standard zipped `dist/` artifact.
- Left unchanged: `pypa/gh-action-pypi-publish@release/v1` (container action, not Node-based) and `codecov/codecov-action@v4` (third-party, not part of the Node-20 deprecation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)