### PR TITLE
fix(rollout): decode routed experts correctly for full-request sglang servers

### DIFF
--- a/src/strands_sglang/rollout.py
+++ b/src/strands_sglang/rollout.py
@@ -75,10 +75,67 @@ class Rollout(BaseModel):
         """Append this turn's base64 routed-experts slice (one `/generate` call covers the turn)."""
         self.routed_experts.append(routed_experts)
 
-    def decode_routed_experts(self, num_layers: int, top_k: int) -> NDArray[np.int32]:
-        """Decode and stitch per-turn routed-experts slices into a shaped numpy array."""
-        buffer = b"".join(pybase64.b64decode(s.encode("ascii")) for s in self.routed_experts)
-        return np.frombuffer(buffer, dtype=np.int32).reshape(-1, num_layers, top_k)
+    def decode_routed_experts(
+        self, num_layers: int, top_k: int, num_tokens: int | None = None
+    ) -> NDArray[np.int32] | None:
+        """Decode the routed-experts capture into a ``[rows, num_layers, top_k]`` array.
+
+        Handles BOTH server behaviors without assuming one:
+
+        - **Per-turn-crop servers** honor ``routed_experts_start_len`` and return only this turn's
+          rows; the per-turn slices must be JOINED to reconstruct the trajectory.
+        - **Full-request servers** ignore ``routed_experts_start_len`` and return routed experts for
+          the WHOLE request on every ``/generate`` call; here the LATEST blob already spans the
+          entire trajectory and joining all blobs would over-count by ~N for an N-hop rollout.
+
+        Disambiguation: when ``num_tokens`` is given (typically ``len(token_ids) - 1``), we pick the
+        interpretation whose row count matches — latest-blob first (full-request server), then
+        join-all (per-turn-crop server). When ``num_tokens`` is NOT given we cannot tell the two
+        apart, so we keep the legacy per-turn-crop contract and JOIN, falling back to the latest
+        blob only if the join does not reshape cleanly. The element width is inferred from the blob
+        size (current sglang emits int32, older builds int8) rather than hardcoded.
+
+        Args:
+            num_layers: MoE layer count (per-token slab depth).
+            top_k: router top-k (per-token slab width).
+            num_tokens: if given, the expected row count. When NEITHER interpretation matches it in
+                either dtype, returns ``None`` so the caller can drop the sample rather than feed
+                misaligned routing into replay. If ``None``, rows are inferred.
+
+        Returns:
+            A ``[rows, num_layers, top_k]`` array, or ``None`` if there is no capture or the blob
+            size is inconsistent with the requested shape.
+        """
+        if not self.routed_experts:
+            return None
+        per_token = num_layers * top_k
+        latest = pybase64.b64decode(self.routed_experts[-1].encode("ascii"))
+        joined = b"".join(pybase64.b64decode(s.encode("ascii")) for s in self.routed_experts)
+
+        def _reshape(raw: bytes, rows: int | None) -> NDArray[np.int32] | None:
+            for dtype in (np.int32, np.int8):
+                itemsize = np.dtype(dtype).itemsize
+                if len(raw) % itemsize != 0:
+                    continue
+                count = len(raw) // itemsize
+                if rows is not None:
+                    if count == rows * per_token:
+                        return np.frombuffer(raw, dtype=dtype).reshape(rows, num_layers, top_k)
+                elif per_token and count % per_token == 0:
+                    return np.frombuffer(raw, dtype=dtype).reshape(-1, num_layers, top_k)
+            return None
+
+        if num_tokens is not None:
+            # num_tokens disambiguates: full-request (latest spans all) vs per-turn-crop (join).
+            candidates = (latest, joined)
+        else:
+            # Ambiguous: keep the legacy per-turn-crop contract (join), fall back to the latest blob.
+            candidates = (joined, latest)
+        for raw in candidates:
+            decoded = _reshape(raw, num_tokens)
+            if decoded is not None:
+                return decoded
+        return None
 
     @property
     def initial_prompt_length(self) -> int:

--- a/src/strands_sglang/sglang.py
+++ b/src/strands_sglang/sglang.py
@@ -379,7 +379,8 @@ class SGLangModel(Model):
             token_ids=output_ids,
             logprobs=[e[0] for e in output_token_logprobs] if output_token_logprobs else None,
         )
-        # Collect this turn's routing slice; decode_routed_experts() stitches the per-turn slices.
+        # Record this turn's routing blob (the server returns experts for the FULL request each call);
+        # decode_routed_experts() reads the latest blob, which spans the whole trajectory.
         if return_routed_experts:
             self.rollout.add_routed_experts(meta_info["routed_experts"])  # KeyError if server omits it
         # Advance the processed-messages cursor (+1 for this turn's assistant response, already in the rollout)

--- a/tests/integration/test_routed_experts.py
+++ b/tests/integration/test_routed_experts.py
@@ -16,8 +16,6 @@
 
 import json
 
-import numpy as np
-
 
 async def test_single_turn_base64_and_decode(routed_experts_model):
     """Single-turn: routed_experts is a list of base64 slices, decode returns correct shape."""
@@ -34,12 +32,15 @@ async def test_single_turn_base64_and_decode(routed_experts_model):
     # JSON-serializable (needed for Ray actor transport)
     json.dumps({"routed_experts": model.rollout.routed_experts})
 
-    # decode_routed_experts returns correct shape
+    # decode_routed_experts returns correct shape. Pass num_tokens so the decode pins the expected
+    # row count (the server returns the full request; decode reads the latest blob).
     if model.moe_num_layers and model.moe_top_k:
         total_tokens = len(model.rollout.token_ids)
-        decoded = model.rollout.decode_routed_experts(num_layers=model.moe_num_layers, top_k=model.moe_top_k)
+        decoded = model.rollout.decode_routed_experts(
+            num_layers=model.moe_num_layers, top_k=model.moe_top_k, num_tokens=total_tokens - 1
+        )
+        assert decoded is not None
         assert decoded.shape == (total_tokens - 1, model.moe_num_layers, model.moe_top_k)
-        assert decoded.dtype == np.int32
 
 
 async def test_multi_turn_agent_with_tools(routed_experts_model, calculator_tool):
@@ -78,7 +79,12 @@ async def test_multi_turn_agent_with_tools(routed_experts_model, calculator_tool
 
     if model.moe_num_layers and model.moe_top_k:
         total_tokens = len(model.rollout.token_ids)
-        decoded = model.rollout.decode_routed_experts(num_layers=model.moe_num_layers, top_k=model.moe_top_k)
+        # Multi-turn: each hop's blob spans the full request; decode reads the latest blob and
+        # pins to num_tokens (the old concat-all path over-counted by ~N hops here).
+        decoded = model.rollout.decode_routed_experts(
+            num_layers=model.moe_num_layers, top_k=model.moe_top_k, num_tokens=total_tokens - 1
+        )
+        assert decoded is not None
         assert decoded.shape == (total_tokens - 1, model.moe_num_layers, model.moe_top_k)
 
 

--- a/tests/unit/test_rollout_routed_experts.py
+++ b/tests/unit/test_rollout_routed_experts.py
@@ -1,0 +1,57 @@
+"""Unit tests for Rollout.decode_routed_experts (multi-turn latest-blob decode)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pybase64
+
+from strands_sglang.rollout import Rollout
+
+_NUM_LAYERS = 4
+_TOP_K = 8
+
+
+def _blob(num_tokens: int, dtype) -> str:
+    """Base64-encode a [num_tokens, num_layers, top_k] routed-experts array of the given dtype."""
+    arr = np.arange(num_tokens * _NUM_LAYERS * _TOP_K, dtype=dtype)
+    return pybase64.b64encode(arr.tobytes()).decode("ascii")
+
+
+def test_decodes_latest_blob_not_concatenation():
+    # The server returns the FULL request on every /generate, so each hop's blob spans the whole
+    # trajectory-so-far. decode must use only the LATEST blob, not join all of them.
+    r = Rollout()
+    r.add_routed_experts(_blob(3, np.int32))  # hop 1: 3 tokens
+    r.add_routed_experts(_blob(7, np.int32))  # hop 2: full trajectory = 7 tokens
+    out = r.decode_routed_experts(_NUM_LAYERS, _TOP_K, num_tokens=7)
+    assert out is not None
+    assert out.shape == (7, _NUM_LAYERS, _TOP_K)
+
+
+def test_int8_dtype_is_detected():
+    r = Rollout()
+    r.add_routed_experts(_blob(5, np.int8))
+    out = r.decode_routed_experts(_NUM_LAYERS, _TOP_K, num_tokens=5)
+    assert out is not None
+    assert out.shape == (5, _NUM_LAYERS, _TOP_K)
+
+
+def test_shape_mismatch_returns_none():
+    # Blob inconsistent with the requested num_tokens -> None (caller drops the sample, no crash).
+    r = Rollout()
+    r.add_routed_experts(_blob(6, np.int32))
+    assert r.decode_routed_experts(_NUM_LAYERS, _TOP_K, num_tokens=9) is None
+
+
+def test_num_tokens_none_infers_rows():
+    # Backward-compatible 2-arg path: rows inferred from blob size.
+    r = Rollout()
+    r.add_routed_experts(_blob(4, np.int32))
+    out = r.decode_routed_experts(_NUM_LAYERS, _TOP_K)
+    assert out is not None
+    assert out.shape == (4, _NUM_LAYERS, _TOP_K)
+
+
+def test_empty_capture_returns_none():
+    assert Rollout().decode_routed_experts(_NUM_LAYERS, _TOP_K) is None
+    assert Rollout().decode_routed_experts(_NUM_LAYERS, _TOP_K, num_tokens=5) is None


### PR DESCRIPTION
## Problem

`Rollout.decode_routed_experts` assumed the sglang server honors `routed_experts_start_len` and returns **only the current turn's** routing rows, so it joined all per-turn base64 blobs to reconstruct the trajectory.

But some sglang builds **ignore `routed_experts_start_len`** and return routed experts for the **full request** on every `/generate` call. For a multi-turn agent each hop re-sends the whole trajectory-so-far, so every blob already spans the full sequence — joining them over-counts by ~N for an N-hop rollout and breaks the downstream `shape[0] == num_tokens` alignment (observed as a routing-replay shape-assert crash during multi-turn GRPO training of a large MoE).

## Fix

Make `decode_routed_experts` handle **both** server behaviors without assuming one:

- Add an optional `num_tokens` arg (the expected row count, typically `len(token_ids) - 1`). When given, pick the interpretation whose row count matches — **latest-blob-spans-all** (full-request server) first, else **join-all** (per-turn-crop server); return `None` on mismatch so the caller can drop the sample instead of feeding misaligned routing into replay.
- When `num_tokens` is **not** given, the two are indistinguishable, so keep the legacy **join** contract (falling back to the latest blob) — existing 2-arg callers are unchanged.
- Infer element dtype (int32/int8) from blob size instead of hardcoding `int32` (varies by engine build).

`sglang.py`: comment-only clarification of the per-turn capture semantics.

## Tests

- New `tests/unit/test_rollout_routed_experts.py`: latest-blob (full-request), int8 detection, shape-mismatch→`None`, `num_tokens=None` infer, empty capture.
- Updated `tests/integration/test_routed_experts.py` to pass `num_tokens` and accept the `| None` return.
- **Full unit suite green: 185 passed** (incl. the pre-existing `TestStreamRoutedExperts` per-turn-crop tests, which still pass via the join path). `ruff` clean.

## Backward compatibility

Additive only — `num_tokens` defaults to `None`; the 2-arg signature and the per-turn-crop join behavior are preserved.
