### PR TITLE
feat!: rename ToolLimiter to LoopLimiter and add max_messages limit

### DIFF
--- a/.claude/commands/add-integration-tests.md
+++ b/.claude/commands/add-integration-tests.md
@@ -7,7 +7,7 @@ The user provides a target as $ARGUMENTS (e.g., a module name, class, or feature
 Follow the existing test style in `tests/integration/`:
 
 - **License header**: Every `.py` file must start with the Apache 2.0 license header (copy from any existing source file)
-- **File naming**: `test_sglang_<focus>.py` for model pipeline tests (e.g., `test_sglang_text.py`, `test_sglang_agent.py`), `test_<feature>.py` for standalone features (e.g., `test_tool_limiter.py`)
+- **File naming**: `test_sglang_<focus>.py` for model pipeline tests (e.g., `test_sglang_text.py`, `test_sglang_agent.py`), `test_<feature>.py` for standalone features (e.g., `test_limiter.py`)
 - **Location**: `tests/integration/`
 - **Async tests**: Use `async def test_*` directly — `asyncio_mode = "auto"` is configured
 - **Shared fixtures**: `conftest.py` provides `sglang_base_url`, `sglang_server_info`, `tokenizer`, `model`, `vlm_model`, `calculator_tool` — use these, don't redefine them

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ The package lives in `src/strands_sglang/` with 7 core modules:
 
 **ToolParser** (`tool_parsers/`) - Abstract base with 5 implementations: `HermesToolParser` (Hermes/Qwen JSON), `QwenXMLToolParser` (XML), `GLM4ToolParser` (GLM-4), `KimiK2ToolParser` (special-token sections), and `DeepSeekV32ToolParser` (DSML-prefixed XML). Strict parsing: only catches JSONDecodeError, propagates failures as tool calls with `raw` content for model feedback. Excludes tool calls inside `<think>` blocks. New parsers self-register via `@register_tool_parser` decorator. Base class provides `validate_tokenizer(tokenizer)` hook for parser-tokenizer compatibility checks. `DeepSeekV32ToolParser` auto-sets `skip_special_tokens=False` in sampling_params to preserve DSML tokens in response text.
 
-**ToolLimiter** (`tool_limiter.py`) - Strands hook enforcing tool iteration and/or call limits per invocation. Supports `max_tool_iters` (one iteration = model response with tool calls + execution) and `max_tool_calls` (individual call count). Raises `MaxToolIterationsReachedError` or `MaxToolCallsReachedError`.
+**LoopLimiter** (`limiter.py`) - Strands hook bounding the agent loop. Supports `max_tool_iters` (one iteration = model response with tool calls + execution), `max_tool_calls` (individual call count), `max_parallel_tool_calls` (excess parallel calls cancelled), and `max_messages` (all roles counted, checked only on user-role messages so the loop stops at a complete message boundary; counters accumulate across invocations until `reset()`, bounding total conversation length in multi-turn env loops). Raises `MaxToolIterationsReachedError`, `MaxToolCallsReachedError`, or `MaxMessagesReachedError`, all subclasses of `LoopLimitReachedError`.
 
 ### Key Design Decisions
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ In principle, Strands-SGLang can be seen as a drop-in agentic rollout service an
 
 Some key highlights of adapting Strands-SGLang to any RL framework:
 - Pass tokens and token metadata from `Rollout` for on-policy rollouts
-- Hook your harness with the built-in `ToolLimiter` (or your own) for controlled rollouts
+- Hook your harness with the built-in `LoopLimiter` (or your own) for controlled rollouts
 - Use a shared `SGLangClient` and HF tokenizer; don't create one instance per rollout
 - Classify the rollout's termination reason properly — it shapes reward and sampling
 

--- a/examples/vlm_agent/vlm_agent.py
+++ b/examples/vlm_agent/vlm_agent.py
@@ -34,7 +34,7 @@ from pathlib import Path
 from strands import Agent, tool
 from transformers import AutoTokenizer
 
-from strands_sglang import SGLangModel, ToolLimiter
+from strands_sglang import LoopLimiter, SGLangModel
 from strands_sglang.client import SGLangClient
 from strands_sglang.tool_parsers import HermesToolParser
 
@@ -113,7 +113,7 @@ async def main():
     agent = Agent(
         model=model,
         tools=[read_image],
-        hooks=[ToolLimiter(max_tool_iters=5)],
+        hooks=[LoopLimiter(max_tool_iters=5)],
         system_prompt="",
         callback_handler=None,
     )

--- a/src/strands_sglang/__init__.py
+++ b/src/strands_sglang/__init__.py
@@ -23,9 +23,15 @@ from .exceptions import (
     SGLangHTTPError,
     SGLangThrottledError,
 )
+from .limiter import (
+    LoopLimiter,
+    LoopLimitReachedError,
+    MaxMessagesReachedError,
+    MaxToolCallsReachedError,
+    MaxToolIterationsReachedError,
+)
 from .rollout import Rollout
 from .sglang import SGLangModel
-from .tool_limiter import MaxToolCallsReachedError, MaxToolIterationsReachedError, ToolLimiter
 from .tool_parsers import get_tool_parser
 from .utils import get_client, get_client_from_slime_args, get_tokenizer
 
@@ -50,7 +56,9 @@ __all__ = [
     # Tool parsing
     "get_tool_parser",
     # Hooks
-    "ToolLimiter",
+    "LoopLimiter",
+    "LoopLimitReachedError",
     "MaxToolIterationsReachedError",
     "MaxToolCallsReachedError",
+    "MaxMessagesReachedError",
 ]

--- a/src/strands_sglang/limiter.py
+++ b/src/strands_sglang/limiter.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Strands hook for limiting tool usage within a single agent invocation."""
+"""Strands hook for bounding the agent loop: tool iterations, tool calls, parallelism, and messages."""
 
 import logging
 from typing import Any
@@ -23,7 +23,11 @@ from strands.hooks.events import BeforeToolCallEvent, MessageAddedEvent
 logger = logging.getLogger(__name__)
 
 
-class MaxToolIterationsReachedError(Exception):
+class LoopLimitReachedError(Exception):
+    """Base class for all limit errors raised by `LoopLimiter`."""
+
+
+class MaxToolIterationsReachedError(LoopLimitReachedError):
     """Raised when the `max_tool_iters` limit is reached.
 
     Notes:
@@ -31,7 +35,7 @@ class MaxToolIterationsReachedError(Exception):
     """
 
 
-class MaxToolCallsReachedError(Exception):
+class MaxToolCallsReachedError(LoopLimitReachedError):
     """Raised when the `max_tool_calls` limit is reached.
 
     Notes:
@@ -39,22 +43,33 @@ class MaxToolCallsReachedError(Exception):
     """
 
 
-class ToolLimiter(HookProvider):
-    """Hook to enforce tool iteration and/or tool call limits on agent tool loops.
+class MaxMessagesReachedError(LoopLimitReachedError):
+    """Raised when the `max_messages` limit is reached.
+
+    Notes:
+        Raised only when a user-role message lands (initial prompt or tool result), ensuring
+        the trajectory ends at a complete message boundary without truncation.
+    """
+
+
+class LoopLimiter(HookProvider):
+    """Hook to bound the agent loop: tool iterations, tool calls, parallel calls, and message count.
 
     Notes:
         - An "iteration" is one cycle of: model generates tool call(s) -> tool(s) execute -> result(s) returned.
         - Multiple parallel tool calls in one model response count as a single iteration but as individual calls.
-        - The limiter raises after the iteration completes (on tool result), ensuring a clean trajectory
-          without requiring token truncation.
+        - Limits raise at complete message boundaries (tool result or user message), ensuring a clean
+          trajectory without requiring token truncation.
+        - Counters accumulate across invocations of the same agent until `reset()` is called, so
+          `max_messages` can bound total conversation length in multi-turn environment loops.
 
     Example:
-        >>> limiter = ToolLimiter(max_tool_iters=5)
+        >>> limiter = LoopLimiter(max_tool_iters=5)
         >>> agent = Agent(model=model, tools=[...], hooks=[limiter])
         >>> try:
         ...     result = agent.invoke("solve this problem")
-        ... except MaxToolIterationsReachedError:
-        ...     # Trajectory is clean - contains exactly 5 complete iterations
+        ... except LoopLimitReachedError:
+        ...     # Trajectory is clean - ends at a complete message boundary
         ...     print(f"Stopped after {limiter.tool_iter_count} iterations")
     """
 
@@ -63,6 +78,7 @@ class ToolLimiter(HookProvider):
         max_tool_iters: int | None = None,
         max_tool_calls: int | None = None,
         max_parallel_tool_calls: int | None = None,
+        max_messages: int | None = None,
     ):
         """Initialize the limiter.
 
@@ -77,16 +93,23 @@ class ToolLimiter(HookProvider):
             max_parallel_tool_calls: Maximum number of parallel tool calls allowed
                 per model response. Excess calls are cancelled and returned to the
                 model as error results. None means no limit.
+            max_messages: Maximum number of messages (all roles) in the conversation.
+                Every message added by the framework is counted, but the limit is only
+                checked when a user-role message lands (initial prompt or tool result)
+                so the loop stops at a complete message boundary. Final count may
+                slightly exceed this limit. None means no limit.
         """
         self.max_tool_iters = max_tool_iters
         self.max_tool_calls = max_tool_calls
         self.max_parallel_tool_calls = max_parallel_tool_calls
+        self.max_messages = max_messages
         self.reset()
 
     def reset(self) -> None:
         """Reset counters for a new invocation."""
         self.tool_iter_count = 0
         self.tool_call_count = 0
+        self.message_count = 0
         self._parallel_call_count = 0
         self.cancelled_tool_call_count = 0
 
@@ -96,14 +119,17 @@ class ToolLimiter(HookProvider):
         registry.add_callback(BeforeToolCallEvent, self._on_before_tool_call)
 
     def _on_message_added(self, event: MessageAddedEvent) -> None:
-        """Count iterations/calls and raise when limit exceeded.
+        """Count messages/iterations/calls and raise when a limit is exceeded.
 
         Notes:
-            - Counts on assistant messages with `toolUse` (model requesting tools)
-            - Raises on user messages with `toolResult` (iteration complete)
+            - Counts every message toward `message_count`
+            - Counts iterations/calls on assistant messages with `toolUse` (model requesting tools)
+            - Raises on user messages: tool limits when a `toolResult` arrives (iteration
+              complete), message limit on any user message (complete message boundary)
         """
         message = event.message
         content = message["content"]
+        self.message_count += 1
 
         # Count when model requests tools
         if message.get("role") == "assistant":
@@ -122,8 +148,9 @@ class ToolLimiter(HookProvider):
                     self.tool_call_count,
                 )
 
-        # Check limit when tool result arrives (iteration complete)
+        # Check limits when a user message arrives (complete message boundary)
         elif message.get("role") == "user":
+            # Tool limits are checked on tool results (iteration complete)
             if any(c.get("toolResult") for c in content):
                 if self.max_tool_iters is not None and self.tool_iter_count >= self.max_tool_iters:
                     logger.debug("Max tool iterations (%d) reached, stopping", self.max_tool_iters)
@@ -137,6 +164,11 @@ class ToolLimiter(HookProvider):
                         f"Max tool calls ({self.max_tool_calls}) reached"
                         " (parallel tool calls count as individual calls)"
                     )
+            # Message limit is checked on any user message, so it also fires before the
+            # first generation of a new invocation when the budget is already exhausted
+            if self.max_messages is not None and self.message_count >= self.max_messages:
+                logger.debug("Max messages (%d) reached, stopping", self.max_messages)
+                raise MaxMessagesReachedError(f"Max messages ({self.max_messages}) reached")
 
     def _on_before_tool_call(self, event: BeforeToolCallEvent) -> None:
         """Cancel excess tool calls when parallel call limit is reached."""

--- a/tests/integration/test_limiter.py
+++ b/tests/integration/test_limiter.py
@@ -12,14 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Integration tests for ToolLimiter."""
+"""Integration tests for LoopLimiter."""
 
 import pytest
 from strands import Agent
 from strands.types.exceptions import EventLoopException
 from strands_tools import calculator
 
-from strands_sglang import MaxToolCallsReachedError, MaxToolIterationsReachedError, ToolLimiter
+from strands_sglang import (
+    LoopLimiter,
+    MaxMessagesReachedError,
+    MaxToolCallsReachedError,
+    MaxToolIterationsReachedError,
+)
 
 SYSTEM_PROMPT = """You are a calculator assistant. You MUST use the calculator tool for ALL arithmetic.
 Never compute in your head - always use the calculator tool."""
@@ -44,7 +49,7 @@ def _unwrap_limiter_error(exc_info):
 
 async def test_max_tool_iters(model):
     """max_tool_iters stops agent after N iterations with clean trajectory and resets correctly."""
-    limiter = ToolLimiter(max_tool_iters=1)
+    limiter = LoopLimiter(max_tool_iters=1)
     agent = Agent(model=model, tools=[calculator], system_prompt=SYSTEM_PROMPT, hooks=[limiter])
 
     # Sequential problem needs >= 2 iterations — should stop after 1
@@ -75,7 +80,7 @@ async def test_max_tool_iters(model):
 
 async def test_max_tool_calls(model):
     """max_tool_calls stops agent after N individual calls; call_count >= iter_count."""
-    limiter = ToolLimiter(max_tool_calls=1)
+    limiter = LoopLimiter(max_tool_calls=1)
     agent = Agent(model=model, tools=[calculator], system_prompt=SYSTEM_PROMPT, hooks=[limiter])
 
     with pytest.raises((MaxToolCallsReachedError, EventLoopException)) as exc_info:
@@ -89,7 +94,7 @@ async def test_max_tool_calls(model):
 
 async def test_max_parallel_tool_calls(model):
     """max_parallel_tool_calls cancels excess calls within a single model response."""
-    limiter = ToolLimiter(max_parallel_tool_calls=1, max_tool_iters=5)
+    limiter = LoopLimiter(max_parallel_tool_calls=1, max_tool_iters=5)
     agent = Agent(model=model, tools=[calculator], system_prompt=SYSTEM_PROMPT, hooks=[limiter])
 
     # Multi-calc may trigger parallel calls; limit=1 cancels extras
@@ -109,7 +114,7 @@ async def test_max_parallel_tool_calls(model):
 async def test_both_limits_correct_error_fires(model):
     """When both limits are set, the tighter one fires the correct error type."""
     # Iter-tight: max_tool_iters=1 is tighter than max_tool_calls=100
-    limiter = ToolLimiter(max_tool_iters=1, max_tool_calls=100)
+    limiter = LoopLimiter(max_tool_iters=1, max_tool_calls=100)
     agent = Agent(model=model, tools=[calculator], system_prompt=SYSTEM_PROMPT, hooks=[limiter])
 
     with pytest.raises((MaxToolIterationsReachedError, EventLoopException)) as exc_info:
@@ -118,9 +123,36 @@ async def test_both_limits_correct_error_fires(model):
 
     # Call-tight: max_tool_calls=1 is tighter than max_tool_iters=100
     model.reset()
-    limiter2 = ToolLimiter(max_tool_iters=100, max_tool_calls=1)
+    limiter2 = LoopLimiter(max_tool_iters=100, max_tool_calls=1)
     agent2 = Agent(model=model, tools=[calculator], system_prompt=SYSTEM_PROMPT, hooks=[limiter2])
 
     with pytest.raises((MaxToolCallsReachedError, EventLoopException)) as exc_info:
         await agent2.invoke_async(SEQUENTIAL_PROBLEM)
     assert isinstance(_unwrap_limiter_error(exc_info), MaxToolCallsReachedError)
+
+
+async def test_max_messages(model):
+    """max_messages stops the loop at a message boundary; an exhausted budget raises before generation."""
+    # user(1) -> assistant toolUse(2) -> toolResult(3) >= 3: raises after the first iteration completes
+    limiter = LoopLimiter(max_messages=3)
+    agent = Agent(model=model, tools=[calculator], system_prompt=SYSTEM_PROMPT, hooks=[limiter])
+
+    with pytest.raises((MaxMessagesReachedError, EventLoopException)) as exc_info:
+        await agent.invoke_async(SEQUENTIAL_PROBLEM)
+    assert isinstance(_unwrap_limiter_error(exc_info), MaxMessagesReachedError)
+    assert limiter.message_count == 3
+
+    # Trajectory is clean: ends at the tool result, lengths consistent
+    tm = model.rollout
+    assert len(tm) > 0
+    assert len(tm.token_ids) == len(tm.loss_mask) == len(tm.logprobs)
+    assert sum(1 for is_output, _ in tm.segment_info if is_output) == limiter.tool_iter_count
+
+    # Exhausted budget: the initial user message of a new invocation raises before any generation
+    model.reset()
+    limiter2 = LoopLimiter(max_messages=1)
+    agent2 = Agent(model=model, tools=[calculator], system_prompt=SYSTEM_PROMPT, hooks=[limiter2])
+    with pytest.raises((MaxMessagesReachedError, EventLoopException)) as exc_info:
+        await agent2.invoke_async(SEQUENTIAL_PROBLEM)
+    assert isinstance(_unwrap_limiter_error(exc_info), MaxMessagesReachedError)
+    assert len(model.rollout) == 0  # nothing was generated

--- a/tests/unit/test_limiter.py
+++ b/tests/unit/test_limiter.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Unit tests for ToolLimiter.
+"""Unit tests for LoopLimiter.
 
 Tests the limiter by directly feeding it MessageAddedEvent objects,
 without needing a real agent or server.
@@ -23,7 +23,13 @@ from unittest.mock import Mock
 import pytest
 from strands.hooks.events import BeforeToolCallEvent, MessageAddedEvent
 
-from strands_sglang.tool_limiter import MaxToolCallsReachedError, MaxToolIterationsReachedError, ToolLimiter
+from strands_sglang.limiter import (
+    LoopLimiter,
+    LoopLimitReachedError,
+    MaxMessagesReachedError,
+    MaxToolCallsReachedError,
+    MaxToolIterationsReachedError,
+)
 
 _MOCK_AGENT = Mock()
 
@@ -66,7 +72,7 @@ def _before_tool_call(tool_id: str = "tool-0") -> BeforeToolCallEvent:
     )
 
 
-def _simulate_iteration(limiter: ToolLimiter, parallel_calls: int = 1) -> None:
+def _simulate_iteration(limiter: LoopLimiter, parallel_calls: int = 1) -> None:
     """Simulate one complete iteration: assistant with tools -> tool result.
 
     Raises if a limit is hit on the tool result event.
@@ -80,19 +86,19 @@ def _simulate_iteration(limiter: ToolLimiter, parallel_calls: int = 1) -> None:
 # =============================================================================
 
 
-class TestToolLimiterInit:
+class TestLoopLimiterInit:
     def test_defaults_are_none(self):
-        limiter = ToolLimiter()
+        limiter = LoopLimiter()
         assert limiter.max_tool_iters is None
         assert limiter.max_tool_calls is None
 
     def test_counters_start_at_zero(self):
-        limiter = ToolLimiter(max_tool_iters=5, max_tool_calls=10)
+        limiter = LoopLimiter(max_tool_iters=5, max_tool_calls=10)
         assert limiter.tool_iter_count == 0
         assert limiter.tool_call_count == 0
 
     def test_reset_clears_counters(self):
-        limiter = ToolLimiter(max_tool_iters=10)
+        limiter = LoopLimiter(max_tool_iters=10)
         limiter.tool_iter_count = 3
         limiter.tool_call_count = 7
         limiter.reset()
@@ -108,7 +114,7 @@ class TestToolLimiterInit:
 class TestMaxToolIters:
     def test_raises_after_limit(self):
         """With max_tool_iters=2: iter 1 completes, iter 2 tool result raises (2 >= 2)."""
-        limiter = ToolLimiter(max_tool_iters=2)
+        limiter = LoopLimiter(max_tool_iters=2)
         _simulate_iteration(limiter)  # iter 1: count=1, result check 1 >= 2 -> ok
         limiter._on_message_added(_assistant_with_tools(1))  # iter 2: count=2
         with pytest.raises(MaxToolIterationsReachedError):
@@ -116,7 +122,7 @@ class TestMaxToolIters:
 
     def test_raises_exactly_at_limit(self):
         """Limit is checked on tool result: iter_count >= max_tool_iters."""
-        limiter = ToolLimiter(max_tool_iters=1)
+        limiter = LoopLimiter(max_tool_iters=1)
         # assistant: iter_count becomes 1
         limiter._on_message_added(_assistant_with_tools(1))
         # tool result: check 1 >= 1 -> raise
@@ -124,13 +130,13 @@ class TestMaxToolIters:
             limiter._on_message_added(_tool_result())
 
     def test_allows_under_limit(self):
-        limiter = ToolLimiter(max_tool_iters=5)
+        limiter = LoopLimiter(max_tool_iters=5)
         _simulate_iteration(limiter)
         _simulate_iteration(limiter)
         assert limiter.tool_iter_count == 2
 
     def test_parallel_calls_count_as_one_iteration(self):
-        limiter = ToolLimiter(max_tool_iters=1)
+        limiter = LoopLimiter(max_tool_iters=1)
         # 3 parallel tool calls = 1 iteration
         limiter._on_message_added(_assistant_with_tools(3))
         assert limiter.tool_iter_count == 1
@@ -139,7 +145,7 @@ class TestMaxToolIters:
 
     def test_zero_stops_after_first_iteration(self):
         """max_tool_iters=0 raises on first tool result (1 >= 0)."""
-        limiter = ToolLimiter(max_tool_iters=0)
+        limiter = LoopLimiter(max_tool_iters=0)
         limiter._on_message_added(_assistant_with_tools(1))
         with pytest.raises(MaxToolIterationsReachedError):
             limiter._on_message_added(_tool_result())
@@ -147,7 +153,7 @@ class TestMaxToolIters:
 
     def test_none_means_no_limit(self):
         """max_tool_iters=None (with max_tool_calls also None) never raises but still counts."""
-        limiter = ToolLimiter(max_tool_iters=None)
+        limiter = LoopLimiter(max_tool_iters=None)
         for _ in range(100):
             _simulate_iteration(limiter)
         assert limiter.tool_iter_count == 100
@@ -161,42 +167,42 @@ class TestMaxToolIters:
 class TestMaxToolCalls:
     def test_raises_after_limit(self):
         """3 calls across 2 iterations, limit=2 -> raises on iter 2 result."""
-        limiter = ToolLimiter(max_tool_calls=2)
+        limiter = LoopLimiter(max_tool_calls=2)
         _simulate_iteration(limiter, parallel_calls=1)  # 1 call total
         limiter._on_message_added(_assistant_with_tools(2))  # 3 calls total
         with pytest.raises(MaxToolCallsReachedError):
             limiter._on_message_added(_tool_result())
 
     def test_raises_exactly_at_limit(self):
-        limiter = ToolLimiter(max_tool_calls=1)
+        limiter = LoopLimiter(max_tool_calls=1)
         limiter._on_message_added(_assistant_with_tools(1))
         with pytest.raises(MaxToolCallsReachedError):
             limiter._on_message_added(_tool_result())
 
     def test_parallel_calls_counted_individually(self):
         """3 parallel calls in one response should count as 3."""
-        limiter = ToolLimiter(max_tool_calls=2)
+        limiter = LoopLimiter(max_tool_calls=2)
         limiter._on_message_added(_assistant_with_tools(3))
         assert limiter.tool_call_count == 3
         with pytest.raises(MaxToolCallsReachedError):
             limiter._on_message_added(_tool_result())
 
     def test_allows_under_limit(self):
-        limiter = ToolLimiter(max_tool_calls=10)
+        limiter = LoopLimiter(max_tool_calls=10)
         _simulate_iteration(limiter, parallel_calls=3)  # 3 calls
         _simulate_iteration(limiter, parallel_calls=2)  # 5 calls
         assert limiter.tool_call_count == 5
 
     def test_none_means_no_limit(self):
         """max_tool_calls=None (with max_tool_iters also None) never raises but still counts."""
-        limiter = ToolLimiter(max_tool_calls=None)
+        limiter = LoopLimiter(max_tool_calls=None)
         for _ in range(50):
             _simulate_iteration(limiter, parallel_calls=3)
         assert limiter.tool_call_count == 150
 
     def test_zero_stops_after_first_call(self):
         """max_tool_calls=0 raises on first tool result."""
-        limiter = ToolLimiter(max_tool_calls=0)
+        limiter = LoopLimiter(max_tool_calls=0)
         limiter._on_message_added(_assistant_with_tools(1))
         with pytest.raises(MaxToolCallsReachedError):
             limiter._on_message_added(_tool_result())
@@ -210,14 +216,14 @@ class TestMaxToolCalls:
 class TestBothLimits:
     def test_iter_limit_fires_first(self):
         """iter limit=1, call limit=10 -> MaxToolIterationsReachedError."""
-        limiter = ToolLimiter(max_tool_iters=1, max_tool_calls=10)
+        limiter = LoopLimiter(max_tool_iters=1, max_tool_calls=10)
         limiter._on_message_added(_assistant_with_tools(1))
         with pytest.raises(MaxToolIterationsReachedError):
             limiter._on_message_added(_tool_result())
 
     def test_call_limit_fires_first(self):
         """iter limit=10, call limit=2 -> MaxToolCallsReachedError on 3rd call."""
-        limiter = ToolLimiter(max_tool_iters=10, max_tool_calls=2)
+        limiter = LoopLimiter(max_tool_iters=10, max_tool_calls=2)
         _simulate_iteration(limiter, parallel_calls=1)  # 1 call
         limiter._on_message_added(_assistant_with_tools(2))  # 3 calls total
         with pytest.raises(MaxToolCallsReachedError):
@@ -228,7 +234,7 @@ class TestBothLimits:
 
     def test_iter_checked_before_calls(self):
         """When both limits are hit simultaneously, iter limit takes precedence."""
-        limiter = ToolLimiter(max_tool_iters=1, max_tool_calls=1)
+        limiter = LoopLimiter(max_tool_iters=1, max_tool_calls=1)
         limiter._on_message_added(_assistant_with_tools(1))
         # Both iter_count=1 >= 1 and call_count=1 >= 1, but iter is checked first
         with pytest.raises(MaxToolIterationsReachedError):
@@ -236,7 +242,7 @@ class TestBothLimits:
 
     def test_only_iters_set_ignores_calls(self):
         """max_tool_calls=None should not crash when only iters is set."""
-        limiter = ToolLimiter(max_tool_iters=2, max_tool_calls=None)
+        limiter = LoopLimiter(max_tool_iters=2, max_tool_calls=None)
         _simulate_iteration(limiter, parallel_calls=5)  # 5 calls, 1 iter
         # iter 2: assistant makes 5 calls, then tool result triggers check
         limiter._on_message_added(_assistant_with_tools(5))  # 10 calls, 2 iters
@@ -246,7 +252,7 @@ class TestBothLimits:
 
     def test_only_calls_set_ignores_iters(self):
         """max_tool_iters=None should not crash when only calls is set."""
-        limiter = ToolLimiter(max_tool_iters=None, max_tool_calls=3)
+        limiter = LoopLimiter(max_tool_iters=None, max_tool_calls=3)
         _simulate_iteration(limiter, parallel_calls=2)  # 2 calls, 1 iter
         limiter._on_message_added(_assistant_with_tools(2))  # 4 calls, 2 iters
         with pytest.raises(MaxToolCallsReachedError):
@@ -261,7 +267,7 @@ class TestBothLimits:
 class TestNoLimits:
     def test_both_none_never_raises(self):
         """Both limits None: never raises, but counters are still accurate."""
-        limiter = ToolLimiter()
+        limiter = LoopLimiter()
         for _ in range(100):
             _simulate_iteration(limiter, parallel_calls=3)
         assert limiter.tool_iter_count == 100
@@ -275,14 +281,14 @@ class TestNoLimits:
 
 class TestIgnoredMessages:
     def test_text_only_assistant_not_counted(self):
-        limiter = ToolLimiter(max_tool_iters=1)
+        limiter = LoopLimiter(max_tool_iters=1)
         limiter._on_message_added(_assistant_text_only())
         assert limiter.tool_iter_count == 0
         assert limiter.tool_call_count == 0
 
     def test_text_only_user_not_checked(self):
         """User text message should not trigger limit check."""
-        limiter = ToolLimiter(max_tool_iters=0)
+        limiter = LoopLimiter(max_tool_iters=0)
         # Force count above limit
         limiter.tool_iter_count = 5
         # Text-only user message should NOT raise
@@ -290,7 +296,7 @@ class TestIgnoredMessages:
 
     def test_assistant_with_mixed_content(self):
         """Text + toolUse in same message: counts as 1 iteration with 1 call."""
-        limiter = ToolLimiter(max_tool_iters=5, max_tool_calls=5)
+        limiter = LoopLimiter(max_tool_iters=5, max_tool_calls=5)
         event = MessageAddedEvent(
             agent=_MOCK_AGENT,
             message={
@@ -314,7 +320,7 @@ class TestIgnoredMessages:
 class TestMaxParallelToolCalls:
     def test_first_n_calls_proceed(self):
         """First N calls within limit should not be cancelled."""
-        limiter = ToolLimiter(max_parallel_tool_calls=3)
+        limiter = LoopLimiter(max_parallel_tool_calls=3)
         limiter._on_message_added(_assistant_with_tools(3))
         for i in range(3):
             event = _before_tool_call(f"tool-{i}")
@@ -323,7 +329,7 @@ class TestMaxParallelToolCalls:
 
     def test_excess_calls_cancelled(self):
         """Calls beyond the limit should be cancelled with error message."""
-        limiter = ToolLimiter(max_parallel_tool_calls=2)
+        limiter = LoopLimiter(max_parallel_tool_calls=2)
         limiter._on_message_added(_assistant_with_tools(4))
         # First 2 proceed
         for i in range(2):
@@ -338,7 +344,7 @@ class TestMaxParallelToolCalls:
 
     def test_cancelled_tool_call_count(self):
         """cancelled_tool_call_count should track the number of cancelled calls."""
-        limiter = ToolLimiter(max_parallel_tool_calls=1)
+        limiter = LoopLimiter(max_parallel_tool_calls=1)
         limiter._on_message_added(_assistant_with_tools(3))
         for i in range(3):
             limiter._on_before_tool_call(_before_tool_call(f"tool-{i}"))
@@ -346,7 +352,7 @@ class TestMaxParallelToolCalls:
 
     def test_counter_resets_on_new_turn(self):
         """Parallel call counter resets when a new assistant message with tools arrives."""
-        limiter = ToolLimiter(max_parallel_tool_calls=1)
+        limiter = LoopLimiter(max_parallel_tool_calls=1)
 
         # Turn 1: 1 allowed, 1 cancelled
         limiter._on_message_added(_assistant_with_tools(2))
@@ -368,7 +374,7 @@ class TestMaxParallelToolCalls:
 
     def test_none_means_no_limit(self):
         """max_parallel_tool_calls=None should never cancel."""
-        limiter = ToolLimiter(max_parallel_tool_calls=None)
+        limiter = LoopLimiter(max_parallel_tool_calls=None)
         limiter._on_message_added(_assistant_with_tools(100))
         for i in range(100):
             event = _before_tool_call(f"tool-{i}")
@@ -378,7 +384,7 @@ class TestMaxParallelToolCalls:
 
     def test_zero_cancels_all(self):
         """max_parallel_tool_calls=0 cancels every tool call."""
-        limiter = ToolLimiter(max_parallel_tool_calls=0)
+        limiter = LoopLimiter(max_parallel_tool_calls=0)
         limiter._on_message_added(_assistant_with_tools(2))
         for i in range(2):
             event = _before_tool_call(f"tool-{i}")
@@ -388,7 +394,7 @@ class TestMaxParallelToolCalls:
 
     def test_with_max_tool_iters(self):
         """Per-turn limit works alongside max_tool_iters."""
-        limiter = ToolLimiter(max_tool_iters=2, max_parallel_tool_calls=1)
+        limiter = LoopLimiter(max_tool_iters=2, max_parallel_tool_calls=1)
 
         # Turn 1: 1 allowed, 1 cancelled
         limiter._on_message_added(_assistant_with_tools(2))
@@ -407,7 +413,7 @@ class TestMaxParallelToolCalls:
 
     def test_with_max_tool_calls(self):
         """Per-turn limit works alongside max_tool_calls."""
-        limiter = ToolLimiter(max_tool_calls=4, max_parallel_tool_calls=2)
+        limiter = LoopLimiter(max_tool_calls=4, max_parallel_tool_calls=2)
 
         # Turn 1: assistant requests 3, parallel limit allows 2, 1 cancelled
         # tool_call_count becomes 3 (counted from assistant message)
@@ -427,13 +433,93 @@ class TestMaxParallelToolCalls:
             limiter._on_message_added(_tool_result())
 
     def test_init_default_is_none(self):
-        limiter = ToolLimiter()
+        limiter = LoopLimiter()
         assert limiter.max_parallel_tool_calls is None
 
     def test_reset_clears_parallel_counters(self):
-        limiter = ToolLimiter(max_parallel_tool_calls=1)
+        limiter = LoopLimiter(max_parallel_tool_calls=1)
         limiter._parallel_call_count = 5
         limiter.cancelled_tool_call_count = 3
         limiter.reset()
         assert limiter._parallel_call_count == 0
         assert limiter.cancelled_tool_call_count == 0
+
+
+# =============================================================================
+# max_messages
+# =============================================================================
+
+
+class TestMaxMessages:
+    def test_counts_all_messages(self):
+        """Every message counts toward message_count, regardless of role or content."""
+        limiter = LoopLimiter()
+        limiter._on_message_added(_user_text_only())
+        limiter._on_message_added(_assistant_with_tools(2))
+        limiter._on_message_added(_tool_result())
+        limiter._on_message_added(_assistant_text_only())
+        assert limiter.message_count == 4
+
+    def test_raises_on_tool_result_at_limit(self):
+        """user, assistant, toolResult with limit=3: the 3rd message (user role) raises."""
+        limiter = LoopLimiter(max_messages=3)
+        limiter._on_message_added(_user_text_only())  # 1
+        limiter._on_message_added(_assistant_with_tools(1))  # 2
+        with pytest.raises(MaxMessagesReachedError):
+            limiter._on_message_added(_tool_result())  # 3 >= 3 -> raise
+        assert limiter.message_count == 3
+
+    def test_assistant_message_never_raises(self):
+        """Limit hit by an assistant message: the raise waits for the next user message."""
+        limiter = LoopLimiter(max_messages=2)
+        limiter._on_message_added(_user_text_only())  # 1
+        limiter._on_message_added(_assistant_text_only())  # 2 >= 2, but no raise on assistant
+        assert limiter.message_count == 2
+        # The next invocation's initial user message triggers the raise before any generation
+        with pytest.raises(MaxMessagesReachedError):
+            limiter._on_message_added(_user_text_only())  # 3
+
+    def test_zero_raises_on_first_user_message(self):
+        """max_messages=0 raises on the initial user message, before any generation."""
+        limiter = LoopLimiter(max_messages=0)
+        with pytest.raises(MaxMessagesReachedError):
+            limiter._on_message_added(_user_text_only())
+
+    def test_none_means_no_limit(self):
+        """max_messages=None never raises but still counts."""
+        limiter = LoopLimiter(max_messages=None)
+        for _ in range(100):
+            _simulate_iteration(limiter)
+        assert limiter.message_count == 200
+
+    def test_tool_limits_checked_before_message_limit(self):
+        """When a tool limit and the message limit are hit on the same tool result, the tool limit fires."""
+        limiter = LoopLimiter(max_tool_iters=1, max_messages=2)
+        limiter._on_message_added(_assistant_with_tools(1))  # 1 message, iter 1
+        with pytest.raises(MaxToolIterationsReachedError):
+            limiter._on_message_added(_tool_result())  # 2 messages, both limits hit
+
+    def test_reset_clears_message_count(self):
+        limiter = LoopLimiter(max_messages=10)
+        limiter.message_count = 7
+        limiter.reset()
+        assert limiter.message_count == 0
+
+
+# =============================================================================
+# Exception hierarchy
+# =============================================================================
+
+
+class TestExceptionHierarchy:
+    def test_all_limit_errors_share_base(self):
+        assert issubclass(MaxToolIterationsReachedError, LoopLimitReachedError)
+        assert issubclass(MaxToolCallsReachedError, LoopLimitReachedError)
+        assert issubclass(MaxMessagesReachedError, LoopLimitReachedError)
+
+    def test_base_catches_any_limit(self):
+        """A single `except LoopLimitReachedError` handles all limit types."""
+        limiter = LoopLimiter(max_tool_iters=1)
+        limiter._on_message_added(_assistant_with_tools(1))
+        with pytest.raises(LoopLimitReachedError):
+            limiter._on_message_added(_tool_result())


### PR DESCRIPTION
## Summary

`ToolLimiter` now bounds more of the agent loop than tool usage, so the name no longer fit. This PR renames it to **`LoopLimiter`** (module `limiter.py`, matching the package's single-word module convention) and adds a message-count limit:

- **`max_messages`** — counts every framework-added message (all roles), but the limit is only checked when a **user-role message** lands (initial prompt or tool result), so the loop always stops at a complete message boundary and never truncates an iteration. Counters accumulate across invocations until `reset()`, which lets `max_messages` bound total conversation length in multi-turn environment loops. When the budget is already exhausted at the start of a new invocation, the initial user message raises **before any generation happens** (verified in integration tests: `model.rollout` stays empty).
- **`MaxMessagesReachedError`**, plus a new common base **`LoopLimitReachedError`** — all three limit errors now share it, so a single `except LoopLimitReachedError` handles every limit type. Existing exception names are unchanged (they map 1:1 to the constructor params).

### Design notes

- The check lives in `MessageAddedEvent` (not `BeforeModelCallEvent`) because `max_messages` is an action counter like `tool_iter_count`, and in the strands loop every model call is immediately preceded by a user-role `MessageAddedEvent` — the two check points are timing-equivalent, and this keeps the limiter a single hook.
- Tool limits are checked before the message limit on the same event, preserving existing error precedence.

### Breaking change

`ToolLimiter` and the `strands_sglang.tool_limiter` module are removed with no deprecation alias (pre-1.0 clean break). Import `LoopLimiter` from `strands_sglang` instead.

## Testing

- Unit: 189 passed in an isolated uv venv (new `TestMaxMessages` + `TestExceptionHierarchy` cases)
- Integration: 23 passed, 3 skipped (routed-experts, dense model) against Qwen3.5-4B with `qwen_xml` parser, including the new `test_max_messages`

🤖 Generated with [Claude Code](https://claude.com/claude-code)