### PR TITLE
build!: raise minimum Python to 3.12, test on 3.12 and 3.13

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v7

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,7 +77,7 @@ When adding new modules, changing commands, or altering key design patterns, upd
 - mypy for type checking (strict: `disallow_untyped_defs`, `disallow_incomplete_defs`)
 - Conventional commits enforced by pre-commit hook (feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert)
 - Pre-commit also runs codespell, license header check, mypy, and unit tests
-- Python 3.10+ required
+- Python 3.12+ required
 - asyncio_mode = "auto" for pytest-asyncio, default timeout = 90s
 
 ## Integration Tests with Remote GPU Server

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "strands-sglang"
 dynamic = ["version"]
 description = "SGLang model provider for Strands Agents SDK with Token-in/Token-out support for agentic RL training."
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.12"
 license = {text = "Apache-2.0"}
 authors = [
     { name = "Yuan He", email = "yuanhe.cs.ai@gmail.com" }
@@ -19,9 +19,6 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: 3.12",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]

--- a/src/strands_sglang/client.py
+++ b/src/strands_sglang/client.py
@@ -217,7 +217,7 @@ class SGLangClient:
                         # Non-JSON response — treat as retryable error
                         raise SGLangDecodingError(f"Invalid JSON response: {e}") from e
 
-            except (aiohttp.ClientConnectorError, asyncio.TimeoutError) as e:
+            except (TimeoutError, aiohttp.ClientConnectorError) as e:
                 last_error = SGLangConnectionError(str(e))
                 last_error.__cause__ = e
 

--- a/src/strands_sglang/sglang.py
+++ b/src/strands_sglang/sglang.py
@@ -24,7 +24,9 @@ from typing import (
     Any,
     TypedDict,
     TypeVar,
+    Unpack,
     cast,
+    override,
 )
 
 import pybase64
@@ -38,7 +40,6 @@ from strands.types.exceptions import (
 from strands.types.streaming import StopReason, StreamEvent
 from strands.types.tools import ToolChoice, ToolResultContent, ToolSpec
 from transformers import PreTrainedTokenizerBase
-from typing_extensions import Unpack, override
 
 from .client import SGLangClient
 from .exceptions import SGLangContextLengthError, SGLangThrottledError

--- a/src/strands_sglang/tool_parsers/glm.py
+++ b/src/strands_sglang/tool_parsers/glm.py
@@ -20,9 +20,7 @@ import json
 import logging
 import re
 import uuid
-from typing import Any
-
-from typing_extensions import override
+from typing import Any, override
 
 from .base import ToolParser, ToolParseResult, register_tool_parser
 

--- a/src/strands_sglang/tool_parsers/hermes.py
+++ b/src/strands_sglang/tool_parsers/hermes.py
@@ -20,8 +20,7 @@ import json
 import logging
 import re
 import uuid
-
-from typing_extensions import override
+from typing import override
 
 from .base import ToolParser, ToolParseResult, register_tool_parser
 

--- a/src/strands_sglang/tool_parsers/kimi_k2.py
+++ b/src/strands_sglang/tool_parsers/kimi_k2.py
@@ -19,8 +19,7 @@ from __future__ import annotations
 import json
 import logging
 import re
-
-from typing_extensions import override
+from typing import override
 
 from .base import ToolParser, ToolParseResult, register_tool_parser
 

--- a/src/strands_sglang/tool_parsers/qwen_xml.py
+++ b/src/strands_sglang/tool_parsers/qwen_xml.py
@@ -20,9 +20,7 @@ import json
 import logging
 import re
 import uuid
-from typing import Any
-
-from typing_extensions import override
+from typing import Any, override
 
 from .base import ToolParser, ToolParseResult, register_tool_parser
 


### PR DESCRIPTION
## Summary

Raises the minimum supported Python version from 3.10 to 3.12 and updates the CI test matrix to cover 3.12 and 3.13.

- `pyproject.toml`: `requires-python` `>=3.10` → `>=3.12`
- `.github/workflows/test.yml`: matrix `["3.10", "3.11", "3.12"]` → `["3.12", "3.13"]`
- `CLAUDE.md`: "Python 3.10+ required" → "Python 3.12+ required"

## Knock-on changes

Ruff infers its target version from `requires-python`, so the target is now `py312`. This triggered 11 auto-fixes, all valid now that 3.10/3.11 are dropped:

- `override` moves from `typing_extensions` → `typing` (stdlib since 3.12): `sglang.py`, `glm.py`, `hermes.py`, `kimi_k2.py`, `qwen_xml.py`
- `Unpack` moves from `typing_extensions` → `typing` (since 3.11): `sglang.py`
- `asyncio.TimeoutError` → builtin `TimeoutError` (UP041): `client.py`

`typing_extensions` is no longer imported anywhere (it was only a transitive dependency, never declared — no dependency change needed).

## Notes

- `mypy python_version = "3.12"`, the lint/publish workflows' pinned `3.12`, and the coverage-upload `if: matrix.python-version == '3.12'` all remain valid (3.12 is still the floor and still in the matrix).
- Package classifiers intentionally declare only `Programming Language :: Python :: 3` (no specific versions).

## Verification

- `mypy src/strands_sglang` — clean
- 189 unit tests pass
- All pre-commit hooks pass

> [!WARNING]
> **BREAKING CHANGE:** drops support for Python 3.10 and 3.11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)