### PR TITLE
feat(models): add Bedrock and Bedrock Mantle model factories

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ pytest tests/integration/ -v --sglang-base-url=http://localhost:30000
 
 ## Architecture
 
-The package lives in `src/strands_sglang/` with 7 core modules:
+The package lives in `src/strands_sglang/` with 8 core modules:
 
 **SGLangModel** (`sglang.py`) - Main entry point implementing the Strands `Model` interface. Requires `client` and `tokenizer` (keyword-only). Formats messages using HuggingFace chat templates (`apply_chat_template()`), calls SGLang's `/generate` endpoint (non-streaming by design for RL throughput), tracks TITO trajectory, and parses tool calls. VLM support is auto-detected server-side via `SGLangClient.is_multimodal()` (queries `/get_model_info` for `has_image_understanding`, cached after the first call). When multimodal, accumulates `image_data` (base64 data URLs) and forwards them to SGLang — the server handles image token expansion. Configuration via `SGLangConfig` TypedDict (sampling_params, return_logprob, return_routed_experts, enable_thinking).
 
@@ -57,6 +57,8 @@ The package lives in `src/strands_sglang/` with 7 core modules:
 **ToolParser** (`tool_parsers/`) - Abstract base with 4 implementations: `HermesToolParser` (Hermes/Qwen JSON), `QwenXMLToolParser` (XML), `GLMToolParser` (GLM-4), and `KimiK2ToolParser` (special-token sections). Strict parsing: only catches JSONDecodeError, propagates failures as tool calls with `raw` content for model feedback. Excludes tool calls inside `<think>` blocks. New parsers self-register via `@register_tool_parser` decorator. `SGLangModel` defaults `skip_special_tokens=False` in sampling_params so special-token tool-call formats (e.g. Kimi K2) survive in response text.
 
 **LoopLimiter** (`limiter.py`) - Strands hook bounding the agent loop. Supports `max_tool_iters` (one iteration = model response with tool calls + execution), `max_tool_calls` (individual call count), `max_parallel_tool_calls` (excess parallel calls cancelled), and `max_messages` (all roles counted, checked only on user-role messages so the loop stops at a complete message boundary; counters accumulate across invocations until `reset()`, bounding total conversation length in multi-turn env loops). Raises `MaxToolIterationsReachedError`, `MaxToolCallsReachedError`, or `MaxMessagesReachedError`, all subclasses of `LoopLimitReachedError`.
+
+**Bedrock model factories** (`models.py`) - Optional hosted-inference backends that complement the on-policy `SGLangModel` provider (for eval, data synthesis, reward-model rollouts). Each returns a `ModelFactory` (`Callable[[], Model]`) that builds a **fresh** Strands `Model` per rollout for concurrency isolation. `bedrock_model_factory` wraps `strands.models.bedrock.BedrockModel` (Anthropic/Converse-API), sharing one thread-safe boto3 client across instances and remapping `max_new_tokens`→`max_tokens`. `bedrock_mantle_model_factory` wraps `strands.models.openai_responses.OpenAIResponsesModel` (GPT via the Bedrock Mantle OpenAI Responses API), minting a SigV4 token per factory call via `aws_bedrock_token_generator.provide_token()` and remapping `max_new_tokens`→`max_output_tokens`; when `stateful=True` it neutralizes the class-level `_ModelPlugin._on_after_invocation` hook so local `agent.messages` persist for observation capture. All heavy deps (`boto3`, `strands-agents[openai]`, `aws-bedrock-token-generator`) are imported lazily and gated behind the `bedrock` optional-dependency group.
 
 ### Key Design Decisions
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,37 @@ async def main():
 asyncio.run(main())
 ```
 
+## Bedrock Backends
+
+For evaluation, data synthesis, or reward-model rollouts you can point the same
+`Agent` harness at hosted AWS Bedrock inference instead of a local SGLang server.
+Two factories return a `ModelFactory` (a zero-arg callable that builds a fresh
+Strands `Model` per rollout, keeping concurrent rollouts isolated):
+
+```python
+from strands import Agent
+from strands_sglang import bedrock_model_factory, bedrock_mantle_model_factory
+
+# Anthropic (and other Converse-API) models
+factory = bedrock_model_factory(model_id="us.anthropic.claude-sonnet-4-20250514-v1:0")
+
+# GPT models via the Bedrock Mantle OpenAI Responses API
+factory = bedrock_mantle_model_factory(
+    model_id="openai.gpt-5.4-2026-03-05",
+    region="us-east-2",
+    reasoning={"effort": "high"},
+)
+
+agent = Agent(model=factory())
+```
+
+These backends require extra dependencies (`boto3`, `strands-agents[openai]`,
+`aws-bedrock-token-generator`):
+
+```bash
+pip install strands-sglang[bedrock]
+```
+
 ## RL Training
 
 In principle, Strands-SGLang can be seen as a drop-in agentic rollout service and can be integrated with any RL training framework. A concrete example of training a math coding agent ([ReTool](https://arxiv.org/abs/2504.11536)) is available at [slime/examples/strands_sglang](https://github.com/THUDM/slime/tree/main/examples/strands_sglang).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,11 @@ Repository = "https://github.com/horizon-rl/strands-sglang/"
 Issues = "https://github.com/horizon-rl/strands-sglang/issues"
 
 [project.optional-dependencies]
+bedrock = [
+    "boto3>=1.34.0",
+    "strands-agents[openai]",
+    "aws-bedrock-token-generator>=1.0.0",
+]
 dev = [
     # Testing
     "pytest>=7.0.0",
@@ -56,6 +61,9 @@ dev = [
     # Agent-level testing
     "strands-agents[openai]",
     "strands-agents-tools",
+    # Bedrock backends
+    "boto3>=1.34.0",
+    "aws-bedrock-token-generator>=1.0.0",
 ]
 
 [tool.hatch.version]

--- a/src/strands_sglang/__init__.py
+++ b/src/strands_sglang/__init__.py
@@ -30,6 +30,11 @@ from .limiter import (
     MaxToolCallsReachedError,
     MaxToolIterationsReachedError,
 )
+from .models import (
+    ModelFactory,
+    bedrock_mantle_model_factory,
+    bedrock_model_factory,
+)
 from .rollout import Rollout
 from .sglang import SGLangModel
 from .tool_parsers import get_tool_parser
@@ -51,6 +56,10 @@ __all__ = [
     "SGLangDecodingError",
     # Model
     "SGLangModel",
+    # Bedrock model factories
+    "ModelFactory",
+    "bedrock_model_factory",
+    "bedrock_mantle_model_factory",
     # Rollout
     "Rollout",
     # Tool parsing

--- a/src/strands_sglang/models.py
+++ b/src/strands_sglang/models.py
@@ -1,0 +1,190 @@
+# Copyright 2025-2026 Strands RL Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""AWS Bedrock model factories for Strands Agents.
+
+These factories complement the on-policy `SGLangModel` provider with hosted
+inference backends, so an agent harness can be pointed at Bedrock during
+evaluation, data synthesis, or reward-model rollouts without changing the
+`Agent` wiring. Each factory returns a `ModelFactory` — a zero-arg callable
+that builds a **fresh** Strands `Model` per rollout so concurrent rollouts stay
+isolated.
+
+Two backends are provided:
+
+- `bedrock_model_factory` — Anthropic (and other Converse-API) models via
+  `strands.models.bedrock.BedrockModel`.
+- `bedrock_mantle_model_factory` — GPT models exposed through the Bedrock Mantle
+  OpenAI Responses API, via `strands.models.openai_responses.OpenAIResponsesModel`.
+
+Both depend on optional packages (`boto3`, `strands-agents[openai]`,
+`aws-bedrock-token-generator`); imports are deferred so the core provider stays
+lightweight. Install with `pip install strands-sglang[bedrock]`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    import boto3
+    import botocore.config
+    from strands.models import Model
+    from strands.models.bedrock import BedrockModel
+    from strands.models.openai_responses import OpenAIResponsesModel
+
+#: Factory that produces a fresh `Model` per rollout (for concurrent rollout isolation).
+ModelFactory = Callable[[], "Model"]
+
+#: Other parameters like temperature and top_p fall back to the model's defaults if unset.
+DEFAULT_SAMPLING_PARAMS: dict[str, Any] = {"max_new_tokens": 16384}
+
+
+def _default_boto_client_config() -> botocore.config.Config:
+    """Return a botocore config tuned for high-concurrency, long-running rollouts."""
+    import botocore.config
+
+    return botocore.config.Config(
+        retries={"max_attempts": 5, "mode": "adaptive"},
+        max_pool_connections=100,
+        connect_timeout=5.0,
+        read_timeout=600.0,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Bedrock Model (Anthropic and other Converse-API models)
+# ---------------------------------------------------------------------------
+
+
+def bedrock_model_factory(
+    *,
+    model_id: str,
+    boto_session: boto3.Session | None = None,
+    boto_client_config: botocore.config.Config | None = None,
+    sampling_params: dict[str, Any] = DEFAULT_SAMPLING_PARAMS,
+) -> ModelFactory:
+    """Return a factory that creates `BedrockModel` instances.
+
+    Args:
+        model_id: Bedrock model ID (e.g. `"us.anthropic.claude-sonnet-4-20250514-v1:0"`).
+        boto_session: Boto3 session for AWS credentials. Defaults to a fresh `boto3.Session()`
+            (standard credential-resolution chain).
+        boto_client_config: Botocore client configuration. Defaults to an adaptive-retry config
+            tuned for long-running, high-concurrency rollouts.
+        sampling_params: Sampling parameters for the model (e.g. `{"max_new_tokens": 4096}`).
+
+    Notes:
+        - A single boto3 client (thread-safe) is created once from the session and shared across
+          all model instances. `BedrockModel` doesn't accept a pre-built client, so we extract it
+          from a pilot instance and override `model.client` on each subsequent one.
+        - The principle of operation is "one boto3 session, one boto3 client".
+        - `max_new_tokens` in `sampling_params` is remapped to `max_tokens` for the Bedrock API.
+        - Requires the `bedrock` extras: `pip install strands-sglang[bedrock]`.
+    """
+    import boto3
+    from strands.models.bedrock import BedrockModel
+
+    if boto_session is None:
+        boto_session = boto3.Session()
+    if boto_client_config is None:
+        boto_client_config = _default_boto_client_config()
+
+    sampling_params = dict(sampling_params)
+    if "max_new_tokens" in sampling_params:
+        sampling_params["max_tokens"] = sampling_params.pop("max_new_tokens")
+
+    model_kwargs = dict(
+        model_id=model_id,
+        boto_session=boto_session,
+        boto_client_config=boto_client_config,
+        streaming=False,
+        **sampling_params,
+    )
+
+    # Build one model to extract a properly configured, thread-safe client.
+    shared_client = BedrockModel(**model_kwargs).client
+
+    def factory() -> BedrockModel:
+        model = BedrockModel(**model_kwargs)
+        model.client = shared_client
+        return model
+
+    return factory
+
+
+# ---------------------------------------------------------------------------
+# Bedrock Mantle Model (GPT via OpenAI Responses API on AWS)
+# ---------------------------------------------------------------------------
+
+
+def bedrock_mantle_model_factory(
+    *,
+    model_id: str,
+    region: str = "us-east-2",
+    sampling_params: dict[str, Any] = DEFAULT_SAMPLING_PARAMS,
+    reasoning: dict[str, Any] | None = None,
+    stateful: bool = True,
+) -> ModelFactory:
+    """Return a factory that creates `OpenAIResponsesModel` for GPT models via Bedrock Mantle.
+
+    Args:
+        model_id: Bedrock Mantle model ID (e.g. `"openai.gpt-5.4-2026-03-05"`).
+        region: AWS region hosting Bedrock Mantle (default `"us-east-2"`).
+        sampling_params: Sampling parameters for the model (e.g. `{"max_new_tokens": 16384}`).
+        reasoning: Reasoning configuration (e.g. `{"effort": "high"}`).
+        stateful: Enable server-side conversation state via previous_response_id.
+            When True, reasoning context carries over between turns.
+
+    Notes:
+        - Uses `aws_bedrock_token_generator.provide_token()` for SigV4 auth.
+        - A fresh token is minted on each factory call to avoid expiry issues.
+        - Requires the `bedrock` extras: `pip install strands-sglang[bedrock]`.
+    """
+    from strands.models.openai_responses import OpenAIResponsesModel
+
+    base_url = f"https://bedrock-mantle.{region}.api.aws/openai/v1"
+
+    sampling_params = dict(sampling_params)
+    if "max_new_tokens" in sampling_params:
+        sampling_params["max_output_tokens"] = sampling_params.pop("max_new_tokens")
+
+    params: dict[str, Any] = {**sampling_params}
+    if reasoning:
+        params["reasoning"] = reasoning
+
+    # Patch the class-level hook that clears agent.messages after invocation.
+    # Strands clears messages for stateful models (server owns state), but a harness that
+    # captures observations from local messages needs them to persist across turns.
+    if stateful:
+        from strands.models.model import _ModelPlugin
+
+        _ModelPlugin._on_after_invocation = staticmethod(lambda event: None)  # type: ignore[method-assign]
+
+    def factory() -> OpenAIResponsesModel:
+        from aws_bedrock_token_generator import provide_token
+
+        token = provide_token(region=region)
+        return OpenAIResponsesModel(
+            model_id=model_id,
+            params=params,
+            stateful=stateful,
+            client_args={
+                "base_url": base_url,
+                "api_key": token,
+            },
+        )
+
+    return factory

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -1,0 +1,111 @@
+# Copyright 2025-2026 Strands RL Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the Bedrock model factories."""
+
+from unittest.mock import MagicMock, patch
+
+from strands_sglang.models import bedrock_mantle_model_factory, bedrock_model_factory
+
+
+class TestBedrockModelFactory:
+    """Tests for bedrock_model_factory (Anthropic / Converse-API models)."""
+
+    def test_remaps_max_new_tokens_and_shares_client(self):
+        """max_new_tokens is remapped to max_tokens and one client is shared across instances."""
+        instances = []
+
+        def make_model(**kwargs):
+            model = MagicMock()
+            model.kwargs = kwargs
+            model.client = MagicMock(name=f"client-{len(instances)}")
+            instances.append(model)
+            return model
+
+        with patch("strands.models.bedrock.BedrockModel", side_effect=make_model) as bedrock_cls:
+            factory = bedrock_model_factory(
+                model_id="us.anthropic.claude-sonnet-4-20250514-v1:0",
+                boto_session=MagicMock(),
+                sampling_params={"max_new_tokens": 4096},
+            )
+            model_a = factory()
+            model_b = factory()
+
+        # Pilot instance + two factory calls == three constructions.
+        assert bedrock_cls.call_count == 3
+        # max_new_tokens was remapped; max_new_tokens must not leak through.
+        _, kwargs = bedrock_cls.call_args_list[0]
+        assert kwargs["max_tokens"] == 4096
+        assert "max_new_tokens" not in kwargs
+        assert kwargs["streaming"] is False
+        # The pilot client is shared onto every subsequent model.
+        assert model_a.client is instances[0].client
+        assert model_b.client is instances[0].client
+
+    def test_defaults_session_and_config(self):
+        """A missing boto_session/config falls back to defaults without error."""
+        with (
+            patch("strands.models.bedrock.BedrockModel", side_effect=lambda **k: MagicMock()),
+            patch("boto3.Session") as session_cls,
+        ):
+            factory = bedrock_model_factory(model_id="model-x")
+            factory()
+        session_cls.assert_called_once_with()
+
+
+class TestBedrockMantleModelFactory:
+    """Tests for bedrock_mantle_model_factory (GPT via OpenAI Responses API)."""
+
+    def test_builds_responses_model_with_token_auth(self):
+        """The factory mints a token per call and points the client at the Mantle base URL."""
+        responses_cls = MagicMock(name="OpenAIResponsesModel")
+        with (
+            patch("strands.models.openai_responses.OpenAIResponsesModel", responses_cls),
+            patch("aws_bedrock_token_generator.provide_token", return_value="tok-123") as provide_token,
+        ):
+            factory = bedrock_mantle_model_factory(
+                model_id="openai.gpt-5.4-2026-03-05",
+                region="us-east-2",
+                sampling_params={"max_new_tokens": 16384},
+                reasoning={"effort": "high"},
+                stateful=False,
+            )
+            factory()
+
+        provide_token.assert_called_once_with(region="us-east-2")
+        _, kwargs = responses_cls.call_args
+        assert kwargs["model_id"] == "openai.gpt-5.4-2026-03-05"
+        assert kwargs["stateful"] is False
+        assert kwargs["client_args"]["base_url"] == "https://bedrock-mantle.us-east-2.api.aws/openai/v1"
+        assert kwargs["client_args"]["api_key"] == "tok-123"
+        # max_new_tokens -> max_output_tokens; reasoning forwarded.
+        assert kwargs["params"]["max_output_tokens"] == 16384
+        assert "max_new_tokens" not in kwargs["params"]
+        assert kwargs["params"]["reasoning"] == {"effort": "high"}
+
+    def test_stateful_patches_after_invocation_hook(self):
+        """stateful=True neutralizes the message-clearing hook so local messages persist."""
+        from strands.models.model import _ModelPlugin
+
+        original = _ModelPlugin._on_after_invocation
+        try:
+            with (
+                patch("strands.models.openai_responses.OpenAIResponsesModel", MagicMock()),
+                patch("aws_bedrock_token_generator.provide_token", return_value="tok"),
+            ):
+                bedrock_mantle_model_factory(model_id="openai.gpt-5.4-2026-03-05", stateful=True)
+            # Hook is now a no-op that accepts an event and returns None.
+            assert _ModelPlugin._on_after_invocation(object()) is None
+        finally:
+            _ModelPlugin._on_after_invocation = original


### PR DESCRIPTION
## Summary

Adds hosted-inference **Bedrock backends** that complement the on-policy `SGLangModel` provider. These let the same Strands `Agent` harness be pointed at AWS Bedrock for evaluation, data synthesis, or reward-model rollouts without changing agent wiring.

New module `src/strands_sglang/models.py` with two factories, each returning a `ModelFactory` (`Callable[[], Model]`) that builds a **fresh** Strands `Model` per rollout for concurrency isolation:

- **`bedrock_model_factory`** — Anthropic / Converse-API models via `strands.models.bedrock.BedrockModel`. Builds one pilot instance to extract a thread-safe boto3 client and shares it across all model instances ("one session, one client"); remaps `max_new_tokens` → `max_tokens`.
- **`bedrock_mantle_model_factory`** — GPT models via the Bedrock Mantle OpenAI Responses API (`strands.models.openai_responses.OpenAIResponsesModel`). Mints a SigV4 token per factory call via `aws_bedrock_token_generator.provide_token()`; remaps `max_new_tokens` → `max_output_tokens`; forwards `reasoning` config. When `stateful=True`, neutralizes the class-level `_ModelPlugin._on_after_invocation` hook so local `agent.messages` persist for observation capture.

The `bedrock` and `bedrock-mantle` backends were both ported from RufusGym's `core/models.py` so the two live side by side as parallel backends.

## Details

- Heavy deps (`boto3`, `strands-agents[openai]`, `aws-bedrock-token-generator`) are imported **lazily** and gated behind a new `[bedrock]` optional-dependency group, keeping the core provider lightweight.
- Exports `bedrock_model_factory`, `bedrock_mantle_model_factory`, and `ModelFactory` from the package root.
- README gains a **Bedrock Backends** section; CLAUDE.md documents the new module.

## Testing

- `tests/unit/test_models.py` — 4 unit tests covering sampling-param remapping, shared-client behavior, token auth + base URL wiring, and the stateful hook patch (all deps mocked; no network/credentials needed).
- `ruff check` / `ruff format --check` clean, `mypy src/strands_sglang` clean, full unit suite **193 passed**.