### PR TITLE
docs: record why format_messages skips toolUse blocks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,7 @@ The package lives in `src/strands_sglang/` with 7 core modules:
 - **Incremental tokenization**: First call tokenizes full prompt; subsequent calls only tokenize new messages (tool results) with message separator prepended
 - **Strict tool parsing for RL**: No heuristic repair of malformed tool calls; errors propagated to model for self-correction
 - **Segment-based TITO**: Token tracking mirrors multi-turn structure (prompt=no loss, response=loss)
+- **toolUse blocks skipped in message formatting**: `format_messages()` drops `toolUse` content blocks because tool calls already live verbatim in the assistant's text block (`stream()` yields the full raw text including `<tool_call>` markup, then parsed toolUse blocks separately — so Strands history holds both). Rendering toolUse via the chat template's `tool_calls` field would duplicate the call in the prompt and cause retokenization drift vs. the actual generated tokens
 - **VLM via server-side expansion**: Multimodal support is auto-detected from the server (`/get_model_info` reports `has_image_understanding`). Tokenization always uses `tokenizer.encode()` — the SGLang server handles image token expansion via `image_data`. No `torch`/`torchvision` dependencies needed
 
 ## Maintenance

--- a/src/strands_sglang/sglang.py
+++ b/src/strands_sglang/sglang.py
@@ -205,7 +205,7 @@ class SGLangModel(Model):
                         }
                     )
             else:
-                # Non-tool content → one HF message (text, image, etc.; toolUse skipped)
+                # Non-tool content → one HF message; toolUse skipped: tool calls already live in the text block
                 content = [cls.format_content_block(c, is_multimodal) for c in msg["content"] if "toolUse" not in c]
                 result.append({"role": msg["role"], "content": content if is_multimodal else content[0]})
 


### PR DESCRIPTION
## Summary
- Adds an inline comment explaining why `toolUse` content blocks are filtered out in `format_messages()` — tool calls already exist verbatim in the text block, so including them again via the chat template would duplicate content and cause retokenization drift for TITO.
- Documents this design decision in CLAUDE.md under Key Design Decisions.

## Test plan
- [x] Pre-commit hooks pass (ruff, mypy, unit tests)
- Docs-only change — no runtime behavior modified