### PR TITLE
test: use builtin TimeoutError instead of asyncio.TimeoutError

### DIFF
--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -14,7 +14,6 @@
 
 """Unit tests for SGLangClient (mocked, no server required)."""
 
-import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import aiohttp
@@ -332,7 +331,7 @@ class TestGenerateErrors:
 
     async def test_connection_error_on_timeout(self):
         """asyncio.TimeoutError is wrapped in SGLangConnectionError."""
-        client = _client_with_mock_session(side_effect=asyncio.TimeoutError())
+        client = _client_with_mock_session(side_effect=TimeoutError())
 
         with pytest.raises(SGLangConnectionError):
             await client.generate(input_ids=[1, 2, 3])


### PR DESCRIPTION
## Summary
- Drop the `asyncio` import in `test_client.py` and use the builtin `TimeoutError` directly, since `asyncio.TimeoutError` has been an alias for it since Python 3.11 and the project requires 3.12+.

## Test plan
- [x] `pytest tests/unit/test_client.py -v` passes
- [x] Pre-commit hooks pass (ruff, mypy, unit tests)