### PR TITLE
feat: keep the finished rollout in rollout_history on reset()

### DIFF
--- a/src/strands_sglang/sglang.py
+++ b/src/strands_sglang/sglang.py
@@ -107,7 +107,11 @@ class SGLangModel(Model):
         logger.debug("initialized with config: %s", self.config)
 
     def reset(self) -> None:
-        """Reset all state for a new episode."""
+        """Reset all state for a new episode.
+
+        Notes:
+            This typically serves as a context management breakpoint where conversation history is trimmed.
+        """
         self.rollout = Rollout()
         self.processed_messages = 0
         self.tool_parse_errors = {}

--- a/src/strands_sglang/sglang.py
+++ b/src/strands_sglang/sglang.py
@@ -101,17 +101,20 @@ class SGLangModel(Model):
 
         # State tracking (this makes SGLangModel stateful)
         self.rollout = Rollout()  # token-in/token-out rollout tracker
+        self.rollout_history: list[Rollout] = []  # trajectories closed by earlier reset() calls
         self.processed_messages: int = 0  # multi-turn message cursor
         self.tool_parse_errors: dict[str, int] = {}  # per-tool parse error count
 
         logger.debug("initialized with config: %s", self.config)
 
     def reset(self) -> None:
-        """Reset all state for a new episode.
+        """Reset all state for a new episode, keeping the finished rollout in `rollout_history`.
 
         Notes:
             This typically serves as a context management breakpoint where conversation history is trimmed.
         """
+        if len(self.rollout):
+            self.rollout_history.append(self.rollout)
         self.rollout = Rollout()
         self.processed_messages = 0
         self.tool_parse_errors = {}

--- a/tests/unit/test_sglang.py
+++ b/tests/unit/test_sglang.py
@@ -152,6 +152,40 @@ class TestTokenizePromptMessages:
             model.tokenize_prompt_messages(messages, system_prompt=None)
 
 
+class TestReset:
+    """Tests for reset(), the context management breakpoint between rollouts."""
+
+    def test_keeps_the_finished_rollout(self, model):
+        """The finished rollout is kept, still carrying the loss_mask that makes it trainable."""
+        model.rollout.add_prompt([1, 2, 3])
+        model.rollout.add_response([4, 5], logprobs=[-0.1, -0.2])
+        finished = model.rollout
+
+        model.reset()
+
+        assert model.rollout_history == [finished]
+        assert model.rollout_history[0].loss_mask == [0, 0, 0, 1, 1]
+        assert model.rollout_history[0].logprobs[-2:] == [-0.1, -0.2]
+
+    def test_starts_a_fresh_rollout(self, model):
+        """Rewinding the cursor makes the next prompt tokenize in full."""
+        model.rollout.add_prompt([1, 2, 3])
+        model.processed_messages = 2
+
+        model.reset()
+
+        assert len(model.rollout) == 0
+        assert model.rollout.segment_info == []
+        assert model.processed_messages == 0
+
+    def test_empty_rollout_is_not_kept(self, model):
+        """Back-to-back resets do not accumulate empty rollouts."""
+        model.reset()
+        model.reset()
+
+        assert model.rollout_history == []
+
+
 class TestSortToolResults:
     """Tests for sort_tool_results method."""
 


### PR DESCRIPTION
## What

`reset()` now keeps the finished rollout in a new `SGLangModel.rollout_history` list instead of dropping it, and its docstring records that it is the breakpoint between rollouts.

## Why

`reset()` rewinds `processed_messages`, so the next `stream()` takes the `processed_messages == 0` branch and re-tokenizes the whole conversation in full as the new rollout's prompt. That already made it the right response when a `ConversationManager` trims `agent.messages`: the tokens already in `rollout` were generated against the *untrimmed* history, and `stream()` replays them as a prefix (`input_ids = self.rollout.token_ids + new_input_ids`), so once the history is trimmed they no longer correspond to `agent.messages` — continuing to append would produce exactly the retokenization drift this package exists to prevent.

What was missing is that the finished rollout was discarded. It is still trainable — its `loss_mask` marks which tokens the model generated — so an episode whose context got trimmed mid-flight silently lost every rollout but the last. Keeping them means the episode yields all the trajectories it actually produced.

Empty rollouts are not recorded, so back-to-back resets stay a no-op.

## Notes for reviewers

- **`model.rollout` semantics are unchanged** — it is still the in-progress rollout, so existing consumers (e.g. slime's `generate_with_strands.py`, which reads `model.rollout` then calls `reset()`) keep working untouched. Callers that want every trajectory read `[*model.rollout_history, model.rollout]`.
- **Nothing calls `reset()` automatically.** Deciding *when* a rollout ends stays with the caller; this PR only makes sure nothing is lost when it does. Worth knowing for whoever wires that up:
  - `reduce_context()` is the single convergence point for trimming — `apply_management()` calls it for routine window management, and the reactive overflow path calls it directly (`agent.py:1529`).
  - Trimming **cannot** be detected by comparing `processed_messages` to `len(messages)`. That difference is driven both by the per-turn `+2` growth and by trimming, so one comparison can't separate them: it misses the turn where trimming actually happens (trimming runs *after* generation) and then stays permanently true once cursor and message count plateau.
  - Strands exposes `ConversationManager.removed_message_count`, a clean monotonic counter that explicitly excludes messages inserted by summarization.
  - `SlidingWindowConversationManager` trims on **every** turn once at the window limit, not occasionally — so treating each trim as a rollout boundary yields one rollout per turn at steady state (measured: ~248 prompt tokens to 1 generated token each). Bounding episode length up front (e.g. `LoopLimiter(max_messages=...)`, as `strands-env` does alongside `NullConversationManager`) avoids that regime entirely.

## Test plan

- `pytest tests/unit/` — 192 passed (3 new in `TestReset`; the two covering `rollout_history` fail without this change)
- `ruff check`, `ruff format --check`, `mypy` — clean; all pre-commit hooks pass
- Exercised end-to-end against a live SGLang server (Qwen3.5-4B, tp=8) with `SlidingWindowConversationManager(window_size=4)`: trimming fires mid-episode, the loop keeps running past the window limit, and each retained rollout still carries its `loss_mask=1` tokens and logprobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)