### PR TITLE
fix: derive image_data from messages instead of accumulating it

### DIFF
--- a/src/strands_sglang/sglang.py
+++ b/src/strands_sglang/sglang.py
@@ -246,6 +246,22 @@ class SGLangModel(Model):
             for msg in messages
         ]
 
+    # TODO: add support for other modalities (e.g. audio, video, etc.)
+    @classmethod
+    def collect_image_data(cls, messages: Messages, is_multimodal: bool = False) -> list[str]:
+        """Base64 data URLs of every image in `messages`, in prompt order.
+
+        Notes:
+            Derived from `messages` instead of accumulated turn by turn, so re-running a turn
+            (Strands retries the model call after e.g. a context overflow) yields the same list
+            rather than a second copy of each image. SGLang expands image tokens per entry, so a
+            duplicate would desynchronize the prompt from the tokens tracked in `rollout`.
+        """
+        if not is_multimodal:
+            return []
+        hf_messages = cls.format_messages(cls.sort_tool_results(messages), is_multimodal=True)
+        return [part["image"] for msg in hf_messages for part in msg["content"] if part.get("type") == "image"]
+
     def tokenize_prompt_messages(
         self,
         messages: Messages,
@@ -260,21 +276,9 @@ class SGLangModel(Model):
             - Subsequent calls: uses a fake prefix (system + user) for boundary formatting,
             then subtracts it to extract only incremental tokens.
         """
-
-        # TODO: add support for other modalities (e.g. audio, video, etc.)
-        def update_multimodal_data(hf_messages: list[dict[str, Any]]) -> None:
-            if not is_multimodal:
-                return
-            for msg in hf_messages:
-                for part in msg["content"]:
-                    match part.get("type"):
-                        case "image":
-                            self.rollout.image_data.append(part["image"])
-
         # First call: full prompt with tools
         if self.processed_messages == 0:
             hf_messages = self.format_messages(messages, system_prompt, is_multimodal=is_multimodal)
-            update_multimodal_data(hf_messages)
             tools = self.format_tool_specs(tool_specs) if tool_specs else None
             prompt = cast(
                 str,
@@ -289,7 +293,6 @@ class SGLangModel(Model):
             new_hf_messages = self.format_messages(
                 self.sort_tool_results(messages[self.processed_messages :]), is_multimodal=is_multimodal
             )
-            update_multimodal_data(new_hf_messages)
             fake_messages = [
                 {"role": "system", "content": [{"text": "FAKE SYSTEM PROMPT"}]},
                 {"role": "user", "content": [{"text": "FAKE USER MESSAGE"}]},
@@ -346,6 +349,7 @@ class SGLangModel(Model):
         )
         # Tracking token IDs in the rollout to ensure the token-in feature
         input_ids = self.rollout.token_ids + new_input_ids
+        image_data = self.collect_image_data(messages, is_multimodal=is_multimodal)
 
         # Assistant message start
         yield {"messageStart": {"role": "assistant"}}
@@ -360,7 +364,7 @@ class SGLangModel(Model):
                 logprob_start_len=max(0, len(self.rollout) - 1) if return_logprob else None,
                 return_routed_experts=return_routed_experts,
                 routed_experts_start_len=max(0, len(self.rollout) - 1) if return_routed_experts else 0,
-                image_data=self.rollout.image_data or None,
+                image_data=image_data or None,
             )
 
             # Extract response data
@@ -387,6 +391,8 @@ class SGLangModel(Model):
             token_ids=output_ids,
             logprobs=[e[0] for e in output_token_logprobs] if output_token_logprobs else None,
         )
+        # Record what was sent, so the rollout reflects the images the tokens were generated against.
+        self.rollout.image_data = image_data
         # Collect this turn's routing slice; decode_routed_experts() stitches the per-turn slices.
         if return_routed_experts:
             self.rollout.add_routed_experts(meta_info["routed_experts"])  # KeyError if server omits it

--- a/tests/unit/test_vlm.py
+++ b/tests/unit/test_vlm.py
@@ -20,9 +20,11 @@ import base64
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from strands.types.exceptions import ContextWindowOverflowException
 
 from strands_sglang import SGLangModel
 from strands_sglang.client import SGLangClient
+from strands_sglang.exceptions import SGLangContextLengthError
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -192,14 +194,12 @@ class TestFormatMessagesMultimodal:
 
 class TestImageAccumulation:
     def test_images_accumulated_across_calls(self, vlm_model, mock_tokenizer):
-        """image_data grows across multiple tokenize_prompt_messages calls."""
+        """collect_image_data returns every image in the conversation, in prompt order."""
         # First turn: one image
         messages1 = [{"role": "user", "content": [{"text": "describe"}, _image_block()]}]
-        vlm_model.tokenize_prompt_messages(messages1, system_prompt=None, is_multimodal=True)
-        assert len(vlm_model.rollout.image_data) == 1
+        assert vlm_model.collect_image_data(messages1, is_multimodal=True) == [_RED_PIXEL_DATA_URL]
 
         # Second turn: simulate assistant response + tool result with screenshot
-        vlm_model.rollout.add_prompt([10, 20, 30])
         vlm_model.processed_messages = 2  # len([user_msg]) + 1 after first generation
         messages2 = [
             {"role": "user", "content": [{"text": "describe"}, _image_block()]},
@@ -223,13 +223,16 @@ class TestImageAccumulation:
                 ],
             },
         ]
-        vlm_model.tokenize_prompt_messages(messages2, system_prompt=None, is_multimodal=True)
-        assert len(vlm_model.rollout.image_data) == 2  # 1 from first + 1 from second (tool result image)
+        # 1 from the first user message + 1 from the tool result
+        assert vlm_model.collect_image_data(messages2, is_multimodal=True) == [_RED_PIXEL_DATA_URL] * 2
+
+    def test_text_only_collects_nothing(self, vlm_model):
+        """A text-only server gets no image_data, even when the messages carry images."""
+        messages = [{"role": "user", "content": [{"text": "describe"}, _image_block()]}]
+        assert vlm_model.collect_image_data(messages, is_multimodal=False) == []
 
     def test_reset_clears_accumulated_images(self, vlm_model, mock_tokenizer):
-        messages = [{"role": "user", "content": [{"text": "describe"}, _image_block()]}]
-        vlm_model.tokenize_prompt_messages(messages, system_prompt=None, is_multimodal=True)
-        assert len(vlm_model.rollout.image_data) > 0
+        vlm_model.rollout.image_data = [_RED_PIXEL_DATA_URL]
 
         vlm_model.reset()
         assert vlm_model.rollout.image_data == []
@@ -262,6 +265,45 @@ class TestStreamImageData:
             ):
                 pass
             assert mock_gen.call_args.kwargs["image_data"] is None
+
+    @pytest.mark.asyncio
+    async def test_failed_generate_does_not_duplicate_images(self, vlm_model, mock_tokenizer):
+        """Retrying a turn re-sends the same images, not one copy per attempt.
+
+        Strands re-runs the whole event loop cycle after a `ContextWindowOverflowException`, which
+        calls `stream()` again for the same turn. SGLang expands image tokens per entry in
+        `image_data`, so a duplicated entry desynchronizes the prompt from the tokens we tracked.
+        """
+        calls = []
+
+        async def _generate(**kwargs):
+            calls.append(list(kwargs["image_data"] or []))
+            if len(calls) == 1:
+                raise SGLangContextLengthError("too long", status=400, body="context length exceeded")
+            return {
+                "text": "response",
+                "output_ids": [100],
+                "meta_info": {
+                    "prompt_tokens": 3,
+                    "completion_tokens": 1,
+                    "cached_tokens": 0,
+                    "finish_reason": {"type": "stop"},
+                    "e2e_latency": 0.1,
+                },
+            }
+
+        vlm_model.client.is_multimodal = AsyncMock(return_value=True)
+        messages = [{"role": "user", "content": [{"text": "describe"}, _image_block()]}]
+
+        with patch.object(vlm_model.client, "generate", side_effect=_generate):
+            with pytest.raises(ContextWindowOverflowException):
+                async for _ in vlm_model.stream(messages=messages):
+                    pass
+            async for _ in vlm_model.stream(messages=messages):
+                pass
+
+        assert calls == [[_RED_PIXEL_DATA_URL], [_RED_PIXEL_DATA_URL]]
+        assert vlm_model.rollout.image_data == [_RED_PIXEL_DATA_URL]
 
 
 def _async_mock_generate():


### PR DESCRIPTION
## The bug

A VLM turn that gets re-run sends the same image twice.

`tokenize_prompt_messages()` appended each turn's images to `rollout.image_data` *before* `/generate` was called. That made `image_data` the one piece of rollout state written ahead of a successful response — `token_ids`, `logprobs` and `routed_experts` are all committed after it returns. So a second `stream()` call for the same turn appended a second copy.

Measured on a live server (Qwen3.5-4B, tp=8), one user image, one turn:

```
before:  images sent per /generate attempt: [1, 2]
after:   images sent per /generate attempt: [1, 1]
```

## Why it's reachable

No throttling required. A context-length 400 is non-retryable in `SGLangClient`, so it escapes immediately and `stream()` maps it to `ContextWindowOverflowException`. Strands catches that, calls `conversation_manager.reduce_context()`, and — when trimming succeeds — **re-runs the whole event loop cycle**, which calls `stream()` again for the same turn. Long multi-turn rollouts hitting the context limit is the normal case for RL, not an edge case. (This path predates the `strands-agents>=1.46.0` pin; it does not depend on `ModelRetryStrategy`.)

It matters because SGLang expands image tokens per entry in `image_data`. A duplicated entry means the server expands two images against a prompt containing one placeholder, so the prompt no longer matches the tokens recorded in `rollout` — exactly the retokenization drift this package exists to prevent. `token_ids` stayed correct throughout, since the cursor only advances on success; `image_data` was the only field that broke the rule.

## The fix

`collect_image_data()` derives the list from `messages` on every call instead of accumulating it:

```python
@classmethod
def collect_image_data(cls, messages, is_multimodal=False) -> list[str]:
    if not is_multimodal:
        return []
    hf_messages = cls.format_messages(cls.sort_tool_results(messages), is_multimodal=True)
    return [part["image"] for msg in hf_messages for part in msg["content"] if part.get("type") == "image"]
```

`image_data` becomes a function of the conversation rather than of how many times a turn ran, so re-running a turn is idempotent **by construction** rather than by getting the commit order right. `rollout.image_data` is still populated — assigned, not appended — recording what the successful request actually sent, which is what the integration tests and the `vlm_agent` example read.

Deriving also means no staging field, no change to `rollout.py`, and `tokenize_prompt_messages()` loses its side effect and goes back to only tokenizing.

**Bonus fix:** image ordering for parallel tool results. Deriving routes through `sort_tool_results()`; the old first-turn path skipped it, so images could be ordered differently from the prompt.

Cost is re-encoding base64 each turn: 0.126 ms per 1 MB image, ~26 ms across a 20-turn rollout with one image per turn. Negligible against a `/generate` call.

## On context management

Trimming and this change compose correctly. When a `ConversationManager` trims, `reset()` (#81) clears `rollout` — `image_data` included — and rewinds the cursor, so the next `stream()` re-tokenizes the trimmed conversation in full and re-derives its images. Verified over a trim boundary: `image_data` and the images present in `messages` stay in agreement once the trajectory is broken.

## Test plan

- `pytest tests/unit/` — 194 passed. `test_failed_generate_does_not_duplicate_images` fails without this change (asserts `[1, 2]` != `[1, 1]`); added `test_text_only_collects_nothing` for the text-only server path
- `ruff check`, `ruff format --check`, `mypy` — clean; all pre-commit hooks pass
- End-to-end against a live SGLang server (Qwen3.5-4B, tp=8, real 32×32 PNG) with a forced context overflow: retry re-sends one image, `rollout.image_data == 1`, and the model still answers from the image
- Two existing tests asserted the old contract (that `tokenize_prompt_messages()` writes into the rollout) and were updated to the derived one

🤖 Generated with [Claude Code](https://claude.com/claude-code)