### PR TITLE
feat: inherit BaseModelConfig so context_window_limit can be configured

### DIFF
--- a/src/strands_sglang/sglang.py
+++ b/src/strands_sglang/sglang.py
@@ -22,7 +22,6 @@ from collections.abc import AsyncGenerator, AsyncIterable
 from functools import cached_property
 from typing import (
     Any,
-    TypedDict,
     TypeVar,
     Unpack,
     cast,
@@ -31,7 +30,7 @@ from typing import (
 
 import pybase64
 from pydantic import BaseModel
-from strands.models import Model
+from strands.models import BaseModelConfig, Model
 from strands.types.content import ContentBlock, Messages, SystemContentBlock
 from strands.types.exceptions import (
     ContextWindowOverflowException,
@@ -66,8 +65,13 @@ class SGLangModel(Model):
         >>> model.rollout.logprobs     # Log probabilities
     """
 
-    class SGLangConfig(TypedDict, total=False):
-        """Configuration options for SGLang generation."""
+    class SGLangConfig(BaseModelConfig, total=False):
+        """Configuration options for SGLang generation.
+
+        Notes:
+            Inherits `context_window_limit` from `BaseModelConfig`; conversation managers read it
+            via `Model.context_window_limit` and otherwise fall back to a hardcoded default.
+        """
 
         sampling_params: dict[str, Any] | None  # Passed to /generate endpoint
         return_logprob: bool | None  # Return logprobs for all tokens (default: True)

--- a/tests/unit/test_sglang.py
+++ b/tests/unit/test_sglang.py
@@ -152,6 +152,23 @@ class TestTokenizePromptMessages:
             model.tokenize_prompt_messages(messages, system_prompt=None)
 
 
+class TestConfig:
+    """Tests for context_window_limit, inherited from BaseModelConfig."""
+
+    def test_unset_by_default(self, model):
+        assert model.context_window_limit is None
+
+    def test_set_at_construction(self, mock_tokenizer):
+        """Conversation managers read this; without it they fall back to a hardcoded default."""
+        client = SGLangClient(base_url="http://localhost:30000")
+        model = SGLangModel(client=client, tokenizer=mock_tokenizer, context_window_limit=262144)
+        assert model.context_window_limit == 262144
+
+    def test_set_via_update_config(self, model):
+        model.update_config(context_window_limit=131072)
+        assert model.context_window_limit == 131072
+
+
 class TestReset:
     """Tests for reset(), the context management breakpoint between rollouts."""
 


### PR DESCRIPTION
## What

`SGLangConfig` now inherits `BaseModelConfig`, making `context_window_limit` a typed, settable option:

```python
SGLangModel(client=client, tokenizer=tokenizer, context_window_limit=262144)
```

## Why

`Model.context_window_limit` resolves from the provider's config dict (`models/model.py:178`). `SGLangConfig` didn't carry the key, so it was always `None` and both consumers fell back to a hardcoded `DEFAULT_CONTEXT_WINDOW_LIMIT = 200_000` with a warning:

- `Model.estimate_utilization()` (`models/model.py:307`)
- `ConversationManager._on_before_model_call_threshold()`, which gates proactive compression (`conversation_manager.py:128`)

200k is wrong in both directions for the models this provider serves. The Qwen3.5-4B server I tested against reports `context_len=262144` (matching `tokenizer.model_max_length`), so utilization was over-estimated by ~24%; smaller models sit well below 200k and would be under-estimated, weakening the compression trigger that the limit exists to drive.

Measured before/after, counting the fallback warning from `strands.models.model`:

```
without limit : limit=None,   fallback_warnings=1   (uses 200000)
with limit    : limit=262144, fallback_warnings=0
```

Behavior is unchanged for callers that omit the key — it stays `None` and the existing fallback applies.

## Why not derive it automatically

`tokenizer.model_max_length` looks like an obvious default and matched the server exactly on the models I checked (Qwen3.5-4B 262144, Qwen2.5-32B and Llama-3.1-8B 131072, gpt2 1024). But for some tokenizers it is a sentinel very-large int rather than a real limit, which would silently yield a meaningless utilization ratio. Better for the caller to state it. `/model_info` does not report a context length, so there is no authoritative server-side value to read either.

## Test plan

- `pytest tests/unit/` — 197 passed, including 3 new `TestConfig` cases (unset default, set at construction, set via `update_config`)
- `ruff check`, `ruff format --check`, `mypy` — clean; all pre-commit hooks pass
- Verified against a live agent loop with `proactive_compression=True` that setting the limit removes the fallback warning and uses the real value (numbers above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)