### PR TITLE
docs: fix the stale install commands and the citation author order

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,8 +1,8 @@
 cff-version: 1.2.0
 message: "Please cite strands-sglang if you use this code in your own work."
-title: "SGLang model provider for Strands Agents for on-policy agentic RL training."
+title: "strands-sglang: Bridging Strands Agents for On-Policy Agentic RL Training."
 authors:
-  - family-names: "Yuan"
-    given-names: "He"
+  - family-names: "He"
+    given-names: "Yuan"
 license: Apache-2.0
 url: "https://github.com/strands-rl/strands-sglang/"

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Or install from source with development dependencies:
 ```bash
 git clone https://github.com/strands-rl/strands-sglang.git
 cd strands-sglang
-pip install -e ".[dev]"
+uv sync
 ```
 
 ## Quick Start
@@ -105,8 +105,8 @@ pytest tests/integration/ -v --sglang-base-url=http://localhost:30000
 Contributions welcome! Install pre-commit hooks for code style and commit message validation:
 
 ```bash
-pip install -e ".[dev]"
-pre-commit install -t pre-commit -t commit-msg
+uv sync
+pre-commit install
 ```
 
 This project uses [Conventional Commits](https://www.conventionalcommits.org/). Commit messages must follow the format:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -14,11 +14,11 @@ pytestmark = pytest.mark.integration
 def _get_server_info(base_url: str, timeout: float = 5.0) -> dict:
     """Check server health and get model info.
 
-    Returns:
-        Server info dict with 'model_path' and 'tokenizer_path'.
+    Any failure calls `pytest.exit(returncode=1)` — an unreachable server means every integration
+    test would fail for the same reason, so the session ends here rather than 200 tests later.
 
-    Raises:
-        pytest.exit: If server is not reachable or unhealthy.
+    Returns:
+        The `/model_info` payload, which carries `model_path` and `tokenizer_path`.
     """
     # Health check
     try:


### PR DESCRIPTION
Three small corrections, all things that were wrong rather than merely untidy.

## README's install command didn't work

Two places told readers to run `pip install -e ".[dev]"`. That stopped resolving when #93 moved dev deps to a PEP 735 `[dependency-groups]` table — so the first thing a new contributor tries fails.

Both become `uv sync`, which installs the group by default. `pre-commit install` also loses its explicit `-t pre-commit -t commit-msg`, since `default_install_hook_types` in the config already covers both.

## Citation author was reversed

```yaml
- family-names: "Yuan"   # ← given name
  given-names: "He"      # ← family name
```

A citation tool renders that as "Yuan, H." where the author is **He, Yuan**. `pyproject.toml`'s `"Yuan He"` is given-then-family, so the CFF fields were swapped relative to it.

## A `Raises:` for something you can't catch

`_get_server_info` documented `Raises: pytest.exit`. That isn't an exception a caller catches — it's a function that ends the whole session. The fact moved into the body along with the reason it's the right behaviour: an unreachable server would fail every integration test for the same cause, so stopping at the first is the point.

Its `Returns:` stays — `-> dict` says nothing about `model_path` and `tokenizer_path`.

The `Args:` sections remaining in `tests/` and `examples/` are all on `@tool` functions, where the docstring *is* the schema the model reads. Untouched.