### PR TITLE
docs: align the PyPI description with the rest of the tagline

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "strands-sglang"
 dynamic = ["version"]
-description = "SGLang model provider for Strands Agents SDK with Token-in/Token-out support for agentic RL training."
+description = "SGLang model provider of Strands Agents for on-policy agentic RL training."
 readme = "README.md"
 requires-python = ">=3.12"
 license = "Apache-2.0"


### PR DESCRIPTION
## Why

The one-line description of this project said three different things depending on where you read it. The GitHub repo description and `CITATION.cff` already agree on **on-policy agentic RL training**; only the PyPI metadata was on its own wording.

| Where | Before | After |
|---|---|---|
| `pyproject.toml` (PyPI page) | SGLang model provider **for Strands Agents SDK with Token-in/Token-out support for** agentic RL training. | SGLang model provider **of Strands Agents for on-policy** agentic RL training. |
| GitHub repo description | SGLang model provider of Strands Agents for on-policy agentic RL training. | unchanged |
| `CITATION.cff` | strands-sglang: Bridging Strands Agents for On-Policy Agentic RL Training. | unchanged |

Dropping "with Token-in/Token-out support" is not a loss: TITO is the first feature bullet in the README, where it gets a real explanation rather than a mention. The PyPI blurb is one line of prose and reads better without the parenthetical.

## Not touched

- **`**Agentic RL, done correctly.**`** — the README slogan, a different kind of line from a description; left alone.
- **`AGENTS.md`** — its opening paragraph is documentation for coding agents, not the tagline. It says the same thing at length and is accurate.

The equivalent alignment for `strands-env` is strands-rl/strands-env#244.