### PR TITLE
docs: drop strands-agents-tools from the install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 ## Installation
 
 ```bash
-pip install strands-sglang strands-agents-tools
+pip install strands-sglang
 ```
 
 Or install from source with development dependencies:


### PR DESCRIPTION
`README.md`'s install line still asked readers to install `strands-agents-tools`:

```bash
pip install strands-sglang strands-agents-tools
```

The quickstart stopped needing it in #87, which replaced `strands_tools.calculator`
with a local `@tool` — defined about thirty lines below this very command. So the
first thing a reader runs pulls a package nothing in the README imports, and with it
slack-bolt, pillow, markdownify and aws-requests-auth.

Same class as the install fix in #95: not untidy, wrong.

## Verification

Against the **published 0.6.1** in a clean venv, not the working tree:

```
$ uv pip install strands-sglang        # no second package
$ python qs.py                         # the quickstart's imports + @tool, verbatim
imports OK
tool spec: calculator
parser: QwenXMLToolParser

$ python -c "import strands_tools"
absent — confirms it is not needed
```

The last check matters: it rules out the package arriving transitively, which would
have made the install line redundant rather than wrong.

The from-source block below it already says `uv sync` and is untouched.